### PR TITLE
Fixed ELF header pattern

### DIFF
--- a/patterns/elf.hexpat
+++ b/patterns/elf.hexpat
@@ -21,7 +21,7 @@ struct Elf32_Ehdr {
   Elf32_Word	e_version;
   Elf32_Addr	e_entry;
   Elf32_Off	e_phoff;
-  Elf32_Off     e_shoff;
+  Elf32_Off	e_shoff;
   Elf32_Word	e_flags;
   Elf32_Half	e_ehsize;
   Elf32_Half	e_phentsize;
@@ -48,3 +48,4 @@ struct Elf64_Ehdr {
   Elf64_Half    e_shstrndx;
 };
 
+Elf64_Ehdr header @ 0x00;

--- a/patterns/elf.hexpat
+++ b/patterns/elf.hexpat
@@ -1,5 +1,7 @@
 #pragma MIME application/x-executable
 
+#define EI_NIDENT 16
+
 using Elf32_Addr  = u32;
 using Elf32_Half  = u16;
 using Elf32_Off   = u32;
@@ -13,13 +15,13 @@ using Elf64_Sword = s32;
 using Elf64_Word  = u32;
 
 struct Elf32_Ehdr {
-  Elf32_Word	e_ident;
+  u8            e_ident[EI_NIDENT];
   Elf32_Half	e_type;
   Elf32_Half	e_machine;
   Elf32_Word	e_version;
   Elf32_Addr	e_entry;
-  Elf32_Off	    e_phoff;
-  Elf32_Off	    e_shoff;
+  Elf32_Off	e_phoff;
+  Elf32_Off     e_shoff;
   Elf32_Word	e_flags;
   Elf32_Half	e_ehsize;
   Elf32_Half	e_phentsize;
@@ -30,7 +32,7 @@ struct Elf32_Ehdr {
 };
 
 struct Elf64_Ehdr {
-  Elf64_Word    e_ident;
+  u8            e_ident[EI_NIDENT];
   Elf64_Half    e_type;
   Elf64_Half    e_machine;
   Elf64_Word    e_version;
@@ -46,4 +48,3 @@ struct Elf64_Ehdr {
   Elf64_Half    e_shstrndx;
 };
 
-Elf64_Ehdr header @ 0x00;


### PR DESCRIPTION
The e_ident field of ELF header isn't just the four first bytes that composes the magic number "0x7f ELF", it's actually an array with a size of EI_NIDENT (= 16) bytes (see "man elf").