### PR TITLE
Fix : Added pragma for multiple PE MIME types.

### DIFF
--- a/magic/portable_executable_magic
+++ b/magic/portable_executable_magic
@@ -1,6 +1,6 @@
 # A libmagic database containing definition for PE files used by MS-DOS based systems
 
 # MS-DOS Portable Executable
-0x0		string/b	MZ
->(0x3c.l)	string/b	PE\0\0
+0x0		    string/b	MZ      MS-DOS Binary
+>(0x3c.l)	string/b	PE\0\0  Portable Executable
 !:mime application/x-dosexec

--- a/magic/portable_executable_magic
+++ b/magic/portable_executable_magic
@@ -1,0 +1,6 @@
+# A libmagic database containing definition for PE files used by MS-DOS based systems
+
+# MS-DOS Portable Executable
+0x0		string/b	MZ
+>(0x3c.l)	string/b	PE\0\0
+!:mime application/x-dosexec

--- a/patterns/pe.hexpat
+++ b/patterns/pe.hexpat
@@ -1,6 +1,4 @@
 #pragma MIME application/x-dosexec
-#pragma MIME application/octet-stream
-#pragma MIME application/vnd.microsoft.portable-executable
 
 enum MachineType : u16 {
 	Unknown = 0x00,

--- a/patterns/pe.hexpat
+++ b/patterns/pe.hexpat
@@ -1,4 +1,6 @@
 #pragma MIME application/x-dosexec
+#pragma MIME application/octet-stream
+#pragma MIME application/vnd.microsoft.portable-executable
 
 enum MachineType : u16 {
 	Unknown = 0x00,


### PR DESCRIPTION
Some Windows users may have .exe MIME type which isn't application/x-dosexec.
This PR adds pragma for the two other main MIME types used by PE files.

(It was the reason for my ImHex installation to not show up the patterns popup when opening a Portable-Executable file.)