### PR TITLE
Patterns for .zip files and .wav files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Hex patterns, include patterns and magic files for the use with the ImHex Hex Ed
 | ELF  | `application/x-executable` | `patterns/elf.hexpat` | ELF header in elf binaries |
 | PE   | `application/x-dosexec` | `patterns/pe.hexpat` | PE header, COFF header, Standard COFF fields and Windows Specific fields |
 | MIDI | `audio/midi` | `patterns/midi.hexpat` | MIDI header, event fields provided |
+| WAV  | `audio/wav`  | `patterns/wav.hexpat`  | RIFF header, WAVE header, PCM header |
+| ZIP  | `application/zip` | `patterns/zip.hexpat` | End of Central Directory Header, Central Directory File Headers |
 
 ### Include Patterns
 

--- a/patterns/wav.hexpat
+++ b/patterns/wav.hexpat
@@ -1,13 +1,13 @@
 #pragma MIME audio/wav
 
 struct riffHeader{
-	char ckID[4] [[comment("Container Signature")]];
-	u32 ckSize [[comment("Size of RIFF Header")]];
+	char ckID[4] [[comment("Container Signature"), name("RIFF Header Signature")]];
+	u32 ckSize [[comment("Size of RIFF Header"), name("RIFF Chunk Size")]];
 };
 
 struct waveHeader{
-	char format[4] [[comment("This is a WAVE file")]];
-	char ckID[4] [[comment("Format chunk")]];
+	char format[4] [[name("WAVE Header Signature")]];
+	char ckID[4] [[comment("Format Chunk")]];
 	u32 ckSize [[comment("Chunk size")]];
 	u16 wFormatTag;
 	u16 wChannels;

--- a/patterns/wav.hexpat
+++ b/patterns/wav.hexpat
@@ -1,0 +1,29 @@
+#pragma MIME audio/wav
+
+struct riffHeader{
+	char ckID[4] [[comment("Container Signature")]];
+	u32 ckSize [[comment("Size of RIFF Header")]];
+};
+
+struct waveHeader{
+	char format[4] [[comment("This is a WAVE file")]];
+	char ckID[4] [[comment("Format chunk")]];
+	u32 ckSize [[comment("Chunk size")]];
+	u16 wFormatTag;
+	u16 wChannels;
+	u32 dwSamplesPerSec [[comment("Sample Frequency")]];
+	u32 dwAvgBytesPerSec [[comment("BPS - Used to estimate buffer size")]];
+	u16 wBlockAlign;
+};
+
+struct pcmHeader{
+	u16 wBitsPerSample;
+};
+
+struct wavHeader{
+	riffHeader riff;
+	waveHeader wave;
+	pcmHeader pcm;
+};
+
+wavHeader header @0x00;

--- a/patterns/zip.hexpat
+++ b/patterns/zip.hexpat
@@ -1,0 +1,44 @@
+#pragma MIME application/zip
+
+struct EndOfCentralDirectory{
+	u32 headerSignature [[color("00000000")]];
+	u16 diskNum [[comment("Number of this disk "), name("Disk Number")]];
+	u16 diskStart [[comment("Disk where central directory starts "), name("Central Directory Disk Number")]];
+	u16 CDRCount [[comment("Number of central directory records on this disk"), name("Central Directory Entries")]];
+	u16 CentralDirectoryRecordCount [[comment("Total number of entries in the central directory"), name("Total Central Directory Entries")]];
+	u16 CDSize [[comment("Size of central directory (bytes)"), name("Central Directory Size")]];
+	u32 CDOffset [[comment("Offset of start of central directory, relative to start of archive"), name("Central Directory Offset")]];
+	u16 commentLength [[color("00000000")]];
+	char coment[commentLength] [[name("Comment")]];
+};
+
+EndOfCentralDirectory fileInfo @ findSequence(0,0x50,0x4B,0x05,0x06) [[name("End of Central Directory Record")]];
+
+struct CentralDirectoryEntry{
+	
+};
+
+struct CentralDirectoryFileHeader{
+	u32 headerSignature [[color("00000000")]];
+	u16 versionMade [[comment("Version file made by")]];
+	u16 versionExtract [[comment("Minimum version needed to extract")]];
+	u16 generalFlag [[comment("General purpose bit flag"), color("00000000")]];
+	u16 compressionMethod;
+	u16 fileLastModifyTime [[comment("File last modification time")]];
+	u16 fileLastModifyDate [[comment("File last modification date")]];
+	u32 crc32 [[comment("CRC-32 of uncompressed data"), color("00000000")]];
+	u32 compressedSize;
+	u32 uncompressedSize;
+	u16 fileNameLength [[color("00000000")]];
+	u16 extraFieldLength [[color("00000000")]];
+	u16 fileCommentLength [[color("00000000")]];
+	u16 diskNumber [[comment("Disk number where file starts ")]];
+	u16 internalFileAttributes;
+	u32 externalFileAttributes;
+	u32 fileOffset [[comment("Relative offset of local file header. This is the number of bytes between the start of the first disk on which the file occurs, and the start of the local file header. This allows software reading the central directory to locate the position of the file inside the ZIP file.")]];
+	char fileName[fileNameLength];
+	u8 extraField[extraFieldLength];
+	char comment[fileCommentLength];
+};
+
+CentralDirectoryFileHeader centralDirHeaders[readUnsigned(findSequence(0,0x50,0x4B,0x05,0x06)+10,2)] @ findSequence(0,0x50,0x4b,0x01,0x02) [[name("Files")]];


### PR DESCRIPTION
Pattern for zip file parses End of Central Directory Header and Central Directory File Headers

Pattern for wav file parses RIFF header, WAVE header, and PCM header