### PR TITLE
Handles application/x-sharedlib mime-type as ELF binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Hex patterns, include patterns and magic files for the use with the ImHex Hex Ed
 | Name | MIME | Path | Description |
 |------|------|------|-------------|
 | BMP  | `image/bmp` | `patterns/bmp.hexpat` | OS2/Windows Bitmap files |
-| ELF  | `application/x-executable` | `patterns/elf.hexpat` | ELF header in elf binaries |
+| ELF  | `application/x-executable`, `application/x-sharedlib` | `patterns/elf.hexpat` | ELF header in elf binaries |
 | PE   | `application/x-dosexec` | `patterns/pe.hexpat` | PE header, COFF header, Standard COFF fields and Windows Specific fields |
 | MIDI | `audio/midi` | `patterns/midi.hexpat` | MIDI header, event fields provided |
 | WAV  | `audio/wav`  | `patterns/wav.hexpat`  | RIFF header, WAVE header, PCM header |
@@ -26,6 +26,7 @@ Hex patterns, include patterns and magic files for the use with the ImHex Hex Ed
 | Name | Path | Description |
 |------|------|-------------|
 | Nintendo Switch | `magic/nintendo_switch_magic` | Identifies common file types used on the Nintendo Switch |
+| Portable Executable | `magic/portable_executable_magic` | Identifies PE files used on Windows
 
 ## Contributing
 

--- a/patterns/elf.hexpat
+++ b/patterns/elf.hexpat
@@ -1,4 +1,5 @@
 #pragma MIME application/x-executable
+#pragma MIME application/x-sharedlib
 
 #define EI_NIDENT 16
 

--- a/patterns/pe.hexpat
+++ b/patterns/pe.hexpat
@@ -1,6 +1,4 @@
 #pragma MIME application/x-dosexec
-#pragma MIME application/octet-stream
-#pragma MIME application/vnd.microsoft.portable-executable
 
 enum MachineType : u16 {
 	Unknown = 0x00,

--- a/patterns/pe.hexpat
+++ b/patterns/pe.hexpat
@@ -1,4 +1,6 @@
 #pragma MIME application/x-dosexec
+#pragma MIME application/octet-stream
+#pragma MIME application/vnd.microsoft.portable-executable
 
 enum MachineType : u16 {
 	Unknown = 0x00,


### PR DESCRIPTION
ELF binaries sometimes are shared libraries rather executables. To address this issue, `application/x-sharedlib` pragma was added top of elf.hexpat file.
Also, README.md has been updated to follow current PR and previous PR, where I forgot to add Portable Executable into Magic files entries.