### PR TITLE
patterns: Add GNU program types to ELF

### DIFF
--- a/patterns/elf.hexpat
+++ b/patterns/elf.hexpat
@@ -158,7 +158,11 @@ namespace program {
     LOOS    = 0x60000000,
     HIOS    = 0x6FFFFFFF,
     LOPROC  = 0x70000000,
-    HIPROC  = 0x7FFFFFFF
+    HIPROC  = 0x7FFFFFFF,
+    GNU_EH_FRAME = program::Type::LOOS + 0x474E550,
+    GNU_STACK = program::Type::LOOS + 0x474E551,
+    GNU_RELRO = program::Type::LOOS + 0x474E552,
+    GNU_PROPERTY = program::Type::LOOS + 0x474E553
   };
 
   struct Header {


### PR DESCRIPTION
https://github.com/torvalds/linux/blob/master/include/uapi/linux/elf.h#L38-L41
I'm unsure if this file format allows for exclusion of the namespace so I included it just in case