### PR TITLE
Add DOS datetime types to pattern library

### DIFF
--- a/includes/std/time.pat
+++ b/includes/std/time.pat
@@ -15,12 +15,12 @@ namespace std::time {
 		u16 yday;
 		bool isdst;
 	} [[sealed]];
-	
+
 	union TimeConverter {
 		Time time;
 		u128 value;
 	};
-	
+
 	using EpochTime = u128;
 
 	enum TimeZone : u8 {
@@ -28,44 +28,94 @@ namespace std::time {
 		UTC
 	};
 
+	bitfield DOSDate {
+		day: 5;
+		month: 4;
+		year: 7;
+	} [[sealed]];
+
+	bitfield DOSTime {
+		seconds: 5;
+		minutes: 6;
+		hours: 5;
+	} [[sealed]];
+
+	namespace impl {
+
+		union DOSDateConverter {
+			DOSDate date;
+			u16 value;
+		};
+
+		union DOSTimeConverter {
+			DOSTime time;
+			u16 value;
+		};
+
+	}
+
 	fn epoch() {
 		return builtin::std::time::epoch();
 	};
-	
+
 	fn to_local(EpochTime epoch_time) {
 		TimeConverter converter;
-		
+
 		converter.value = builtin::std::time::to_local(epoch_time);
-	
-		return converter.time;
-	};
-	
-	fn to_utc(EpochTime epoch_time) {
-		TimeConverter converter;
-		
-		converter.value = builtin::std::time::to_utc(epoch_time);
-	
+
 		return converter.time;
 	};
 
+	fn to_utc(EpochTime epoch_time) {
+		TimeConverter converter;
+
+		converter.value = builtin::std::time::to_utc(epoch_time);
+
+		return converter.time;
+	};
 
 	fn now(TimeZone time_zone = TimeZone::Local) {
 		TimeConverter converter;
-	
+
 		if (time_zone == TimeZone::Local)
 			converter.value = builtin::std::time::to_local(std::time::epoch());
 		else if (time_zone == TimeZone::UTC)
 			converter.value = builtin::std::time::to_utc(std::time::epoch());
 		else
 			converter.value = 0x00;
-			
+
 		return converter.time;
 	};
-	
+
+	fn to_dos_date(u16 value) {
+		impl::DOSDateConverter converter;
+
+		converter.value = value;
+
+		return converter.date;
+	};
+
+	fn to_dos_time(u16 value) {
+		impl::DOSTimeConverter converter;
+
+		converter.value = value;
+
+		return converter.time;
+	};
+
 	fn format(Time time, str format_string = "%c") {
 		TimeConverter converter;
 		converter.time = time;
-	
+
 		return builtin::std::time::format(format_string, converter.value);
 	};
+
+	fn format_dos_date(DOSDate date, str format_string = "{}/{}/{}") {
+		return std::format(format_string, date.day, date.month, date.year + 1980);
+	};
+
+	fn format_dos_time(DOSTime time, str format_string = "{:02}:{:02}:{:02}") {
+		return std::format(format_string, time.hours, time.minutes, time.seconds * 2);
+	};
+
 }

--- a/includes/type/time.pat
+++ b/includes/type/time.pat
@@ -4,14 +4,24 @@
 #include <std/time.pat>
 
 namespace type {
-    
+
     using time32_t = u32 [[format("type::impl::format_time_t")]];
     using time64_t = u64 [[format("type::impl::format_time_t")]];
+    using dosdate16_t = u16 [[format("type::impl::format_dosdate16_t")]];
+    using dostime16_t = u16 [[format("type::impl::format_dostime16_t")]];
 
     namespace impl {
 
-        fn format_time_t(u128 value) {	
+        fn format_time_t(u128 value) {
             return std::time::format(std::time::to_utc(value));
+        };
+
+        fn format_dosdate16_t(u16 value) {
+            return std::time::format_dos_date(std::time::to_dos_date(value));
+        };
+
+        fn format_dostime16_t(u16 value) {
+            return std::time::format_dos_time(std::time::to_dos_time(value));
         };
 
     }


### PR DESCRIPTION
This matches the implementation in the inspector for DOS Date and DOS Time. Useful for old formats (such as ZIP).