### PR TITLE
Minor cleanup to zip pattern

### DIFF
--- a/patterns/zip.hexpat
+++ b/patterns/zip.hexpat
@@ -3,44 +3,44 @@
 #include <std/mem.pat>
 
 struct EndOfCentralDirectory{
-	u32 headerSignature [[color("00000000")]];
-	u16 diskNum [[comment("Number of this disk "), name("Disk Number")]];
-	u16 diskStart [[comment("Disk where central directory starts "), name("Central Directory Disk Number")]];
-	u16 CDRCount [[comment("Number of central directory records on this disk"), name("Central Directory Entries")]];
-	u16 CentralDirectoryRecordCount [[comment("Total number of entries in the central directory"), name("Total Central Directory Entries")]];
-	u32 CDSize [[comment("Size of central directory (bytes)"), name("Central Directory Size")]];
-	u32 CDOffset [[comment("Offset of start of central directory, relative to start of archive"), name("Central Directory Offset")]];
-	u16 commentLength [[color("00000000")]];
-	char coment[commentLength] [[name("Comment")]];
+    u32 headerSignature [[color("00000000")]];
+    u16 diskNum [[comment("Number of this disk "), name("Disk Number")]];
+    u16 diskStart [[comment("Disk where central directory starts "), name("Central Directory Disk Number")]];
+    u16 CDRCount [[comment("Number of central directory records on this disk"), name("Central Directory Entries")]];
+    u16 CentralDirectoryRecordCount [[comment("Total number of entries in the central directory"), name("Total Central Directory Entries")]];
+    u32 CDSize [[comment("Size of central directory (bytes)"), name("Central Directory Size")]];
+    u32 CDOffset [[comment("Offset of start of central directory, relative to start of archive"), name("Central Directory Offset")]];
+    u16 commentLength [[color("00000000")]];
+    char coment[commentLength] [[name("Comment")]];
 };
 
 EndOfCentralDirectory fileInfo @ std::mem::find_sequence(0,0x50,0x4B,0x05,0x06) [[name("End of Central Directory Record")]];
 
 struct CentralDirectoryEntry{
-	
+
 };
 
 struct CentralDirectoryFileHeader{
-	u32 headerSignature [[color("00000000")]];
-	u16 versionMade [[comment("Version file made by")]];
-	u16 versionExtract [[comment("Minimum version needed to extract")]];
-	u16 generalFlag [[comment("General purpose bit flag"), color("00000000")]];
-	u16 compressionMethod;
-	u16 fileLastModifyTime [[comment("File last modification time")]];
-	u16 fileLastModifyDate [[comment("File last modification date")]];
-	u32 crc32 [[comment("CRC-32 of uncompressed data"), color("00000000")]];
-	u32 compressedSize;
-	u32 uncompressedSize;
-	u16 fileNameLength [[color("00000000")]];
-	u16 extraFieldLength [[color("00000000")]];
-	u16 fileCommentLength [[color("00000000")]];
-	u16 diskNumber [[comment("Disk number where file starts ")]];
-	u16 internalFileAttributes;
-	u32 externalFileAttributes;
-	u32 fileOffset [[comment("Relative offset of local file header. This is the number of bytes between the start of the first disk on which the file occurs, and the start of the local file header. This allows software reading the central directory to locate the position of the file inside the ZIP file.")]];
-	char fileName[fileNameLength];
-	u8 extraField[extraFieldLength];
-	char comment[fileCommentLength];
+    u32 headerSignature [[color("00000000")]];
+    u16 versionMade [[comment("Version file made by")]];
+    u16 versionExtract [[comment("Minimum version needed to extract")]];
+    u16 generalFlag [[comment("General purpose bit flag"), color("00000000")]];
+    u16 compressionMethod;
+    u16 fileLastModifyTime [[comment("File last modification time")]];
+    u16 fileLastModifyDate [[comment("File last modification date")]];
+    u32 crc32 [[comment("CRC-32 of uncompressed data"), color("00000000")]];
+    u32 compressedSize;
+    u32 uncompressedSize;
+    u16 fileNameLength [[color("00000000")]];
+    u16 extraFieldLength [[color("00000000")]];
+    u16 fileCommentLength [[color("00000000")]];
+    u16 diskNumber [[comment("Disk number where file starts ")]];
+    u16 internalFileAttributes;
+    u32 externalFileAttributes;
+    u32 fileOffset [[comment("Relative offset of local file header. This is the number of bytes between the start of the first disk on which the file occurs, and the start of the local file header. This allows software reading the central directory to locate the position of the file inside the ZIP file.")]];
+    char fileName[fileNameLength];
+    u8 extraField[extraFieldLength];
+    char comment[fileCommentLength];
 };
 
 CentralDirectoryFileHeader centralDirHeaders[fileInfo.CDRCount] @ (fileInfo.CDOffset) [[name("Files")]];

--- a/patterns/zip.hexpat
+++ b/patterns/zip.hexpat
@@ -2,7 +2,7 @@
 
 #include <std/mem.pat>
 
-struct EndOfCentralDirectory{
+struct EndOfCentralDirectory {
     u32 headerSignature [[color("00000000")]];
     u16 diskNum [[comment("Number of this disk "), name("Disk Number")]];
     u16 diskStart [[comment("Disk where central directory starts "), name("Central Directory Disk Number")]];
@@ -16,11 +16,7 @@ struct EndOfCentralDirectory{
 
 EndOfCentralDirectory fileInfo @ std::mem::find_sequence(0,0x50,0x4B,0x05,0x06) [[name("End of Central Directory Record")]];
 
-struct CentralDirectoryEntry{
-
-};
-
-struct CentralDirectoryFileHeader{
+struct CentralDirectoryFileHeader {
     u32 headerSignature [[color("00000000")]];
     u16 versionMade [[comment("Version file made by")]];
     u16 versionExtract [[comment("Minimum version needed to extract")]];
@@ -34,10 +30,10 @@ struct CentralDirectoryFileHeader{
     u16 fileNameLength [[color("00000000")]];
     u16 extraFieldLength [[color("00000000")]];
     u16 fileCommentLength [[color("00000000")]];
-    u16 diskNumber [[comment("Disk number where file starts ")]];
+    u16 diskNumber [[comment("Disk number where file starts")]];
     u16 internalFileAttributes;
     u32 externalFileAttributes;
-    u32 fileOffset [[comment("Relative offset of local file header. This is the number of bytes between the start of the first disk on which the file occurs, and the start of the local file header. This allows software reading the central directory to locate the position of the file inside the ZIP file.")]];
+    u32 fileOffset [[comment("Offset of local file header, relative to the start of the first disk on which the file occurs.")]];
     char fileName[fileNameLength];
     u8 extraField[extraFieldLength];
     char comment[fileCommentLength];


### PR DESCRIPTION
I did some minor cosmetic changes to zip.hexpat: cleanup whitespace, remove an unused struct, and shorten a giant field comment that was causing a tooltip wider than my screen.

I'm sending this PR to keep these minor changes separate from my actual additions later :)

By the way, I see most commit messages start with the directory/category name like "patterns:". I did the same for consistency, but if only touching one file, wouldn't it make more sense to put the format name there? Like "png: Add sRGB chunk support".