### PR TITLE
patterns/dmg: Added DMG pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Hex patterns, include patterns and magic files for the use with the ImHex Hex Ed
 | COFF | `application/x-coff` | [`patterns/coff.hexpat`](patterns/coff.hexpat) | Common Object File Format (COFF) executable |
 | Mach-O | `application/x-mach-binary` | [`patterns/macho.hexpat`](patterns/macho.hexpat) | Mach-O executable |
 | CHM | | [`patterns/chm.hexpat`](patterns/chm.hexpat) | Windows HtmlHelp Data (ITSF / CHM) |
+| DMG | | [`patterns/dmg.hexpat`](patterns/dmg.hexpat) | Apple Disk Image Trailer (DMG) |
 
 ### Scripts
 

--- a/patterns/dmg.hexpat
+++ b/patterns/dmg.hexpat
@@ -1,0 +1,50 @@
+#pragma MIME application/octet-stream
+#pragma endian big
+
+#include <type/magic.pat>
+#include <type/size.pat>
+#include <type/guid.pat>
+#include <std/mem.pat>
+
+// Parse DMG Structure per http://newosxbook.com/DMG.html
+//
+// UDIFResourceFile starts at size(file) - 512
+struct UDIFResourceFile {
+    type::Magic<"koly"> Signature;  // Magic ('koly')
+    u32 Version;                    // Current version is 4
+    type::Size<u32> HeaderSize;     // sizeof(this), always 512
+    u32 Flags;
+    u64 RunningDataForkOffset;      // 
+    u64 DataForkOffset;             // Data fork offset (usually 0, beginning of file)
+    type::Size<u64> DataForkLength; // Size of data fork (usually up to the XMLOffset, below)
+    u64 RsrcForkOffset;             // Resource fork offset, if any
+    type::Size<u64> RsrcForkLength; // Resource fork length, if any
+    u32 SegmentNumber;              // Usually 1, may be 0
+    u32 SegmentCount;               // Usually 1, may be 0
+    type::GUID SegmentID;           // 128-bit GUID identifier of segment (if SegmentNumber !=0)
+    
+
+    u32 DataChecksumType;               // Data fork 
+    type::Size<u32> DataChecksumSize;   // Checksum Information
+    u32 DataChecksum[DataChecksumSize]; // Up to 128-bytes (32 x 4) of checksum
+
+    u64 XMLOffset;              // Offset of property list in DMG, from beginning
+    type::Size<u64> XMLLength;  // Length of property list
+    u8  Reserved1[120];         // 120 reserved bytes - zeroed
+
+    u32 ChecksumType;               // Master
+    type::Size<u32> ChecksumSize;   // Checksum information
+    u32 Checksum[ChecksumSize];     // Up to 128-bytes (32 x 4) of checksum
+
+    u32 ImageVariant;          // Commonly 1
+    u64 SectorCount;           // Size of DMG when expanded, in sectors
+
+    u32 reserved2;             // 0
+    u32 reserved3;             // 0 
+    u32 reserved4;             // 0
+};
+
+
+UDIFResourceFile trailer @ std::mem::size() - 512;
+
+char metadata_plist[trailer.XMLLength] @ trailer.XMLOffset;


### PR DESCRIPTION
# Pattern: DMG

This adds the struct/pattern for Apple Disk Images's trailer object (.dmg). This could be further extended by decoding the XML identified as `metadata_plist`, decoding the base64 payload within that and parsing those structs and the compressed objects they relate to if base64 & XML could be added to the[ ImHex decoding library](https://imhex.werwolv.net/docs/libraries/hex/hex_dec.html#decoding-library-1-24-0). 🤔

<img width="835" alt="image" src="https://user-images.githubusercontent.com/21696437/211203565-9179c898-5463-4f70-8e93-7041842ed8b8.png">

## Checklist
- [x] A pattern for this format doesn't exist yet (or this PR improves the existing one)
- [x] The new pattern has been added to the relevant table in the Readme
- [x] The pattern was associated with all relevant MIME types (using `#pragma MIME mime-type` in the source code)
- [ ] A test file for this pattern has been added to [/tests/patterns/test_data](/tests/patterns/test_data)
  - Try to keep this file below ~ 1 MB