### PR TITLE
fix qoi.hexpat: bitfields order

### DIFF
--- a/patterns/qoi.hexpat
+++ b/patterns/qoi.hexpat
@@ -1,5 +1,6 @@
 #pragma MIME image/qoi
 #pragma endian big
+#pragma bitfield_order left_to_right
 
 #include <std/mem.pat>
 


### PR DESCRIPTION
Just figured out the bit fields weren't read correctly.