### PR TITLE
Support null-terminated ustar magic value

### DIFF
--- a/patterns/tar.hexpat
+++ b/patterns/tar.hexpat
@@ -9,7 +9,7 @@
 #include <std/sys.pat>
 
 
-#define GNU_HEADER "ustar "
+#define GNU_HEADER "ustar"
 #define PAX_HEADER "ustar\x00"
 #define NULL "\x00"
 
@@ -83,7 +83,7 @@ struct tar {
     }
 };
 
-char magic[6] @ 0x00000101 [[hidden]];
+char magic[5] @ 0x00000101 [[hidden]];
 std::assert(magic == PAX_HEADER || magic == GNU_HEADER, "Magic bytes are not correct! Perhaps wrong file?");
 
 tar tar[while(!std::mem::eof())] @ 0x000;


### PR DESCRIPTION
The GNU tar cli tool creates tar files where the magic "ustar " constant ends with a space instead of a nul-byte.

The [spec](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html#tagtcjh_28) says it should be a nul-byte though, so just check the first 5 characters and be flexible about the 6th :)
