### PR TITLE
ELF: treat SHT_SYMTAB as symbol tables

### DIFF
--- a/patterns/elf.hexpat
+++ b/patterns/elf.hexpat
@@ -637,7 +637,7 @@ struct Elf32_Shdr {
 		} else if (sh_type == SHT::STRTAB) {
 			String stringTable[while($ < (sh_offset + sh_size))] @ sh_offset;
 			stringTableIndex = std::core::array_index();	
-		} else if (sh_type == SHT::DYNSYM) {
+		} else if (sh_type == SHT::SYMTAB || sh_type == SHT::DYNSYM) {
 			Elf32_Sym symbolTable[sh_size / sh_entsize] @ sh_offset;
 		} else if (sh_type == SHT::INIT_ARRAY || sh_type == SHT::FINI_ARRAY) {
 			u32 pointer[while($ < (sh_offset + sh_size))] @ sh_offset;
@@ -697,7 +697,7 @@ struct Elf64_Shdr {
 		} else if (sh_type == SHT::STRTAB) {
 			String stringTable[while($ < (sh_offset + sh_size))] @ sh_offset;
 			stringTableIndex = std::core::array_index();	
-		} else if (sh_type == SHT::DYNSYM) {
+		} else if (sh_type == SHT::SYMTAB || sh_type == SHT::DYNSYM) {
 			Elf64_Sym symbolTable[sh_size / sh_entsize] @ sh_offset;
 		} else if (sh_type == SHT::INIT_ARRAY || sh_type == SHT::FINI_ARRAY) {
 			u32 pointer[while($ < (sh_offset + sh_size))] @ sh_offset;


### PR DESCRIPTION
`SHT_SYMTAB` follows the same format as `SHT_DYNSYM`, please refer to page 1-12 of ELF file format spec: https://refspecs.linuxbase.org/elf/elf.pdf