### PR TITLE
ELF: make hex view less ambiguous

### DIFF
--- a/includes/std/core.pat
+++ b/includes/std/core.pat
@@ -57,4 +57,13 @@ namespace std::core {
     fn is_valid_enum(ref auto pattern) {
         return builtin::std::core::is_valid_enum(pattern);
     };
+
+
+    fn set_pattern_color(ref auto pattern, u32 color) {
+        builtin::std::core::set_pattern_color(pattern, color);
+    };
+
+    fn set_display_name(ref auto pattern, str name) {
+        builtin::std::core::set_display_name(pattern, name);
+    }; 
 }

--- a/patterns/elf.hexpat
+++ b/patterns/elf.hexpat
@@ -744,17 +744,8 @@ struct ELF {
 
 ELF elf @ 0x00;
 
-fn member_count(ref auto pattern) {
-    return std::core::member_count(pattern);
-};
 
-fn has_member(ref auto pattern, str name) {
-    return std::core::has_member(pattern, name);
-};
-
-fn gen_shdr_disp_name(ref auto pattern,
-                    str member_name,
-                    u8 member_index) {
+fn gen_shdr_disp_name(ref auto pattern, str member_name, u8 member_index) {
     return std::format(
         "{}@shdr[{}]({})",
         member_name,
@@ -763,10 +754,7 @@ fn gen_shdr_disp_name(ref auto pattern,
     );
 };
 
-fn gen_shdr_sub_disp_name(ref auto pattern,
-                    str member_name,
-                    u8 member_index,
-                    u64 submember_index) {
+fn gen_shdr_sub_disp_name(ref auto pattern, str member_name, u8 member_index, u64 submember_index) {
     return std::format(
         "{}[{}]@shdr[{}]({})",
         member_name,
@@ -776,9 +764,7 @@ fn gen_shdr_sub_disp_name(ref auto pattern,
     );
 };
 
-fn gen_phdr_disp_name(ref auto pattern,
-                    str member_name,
-                    u8 member_index) {
+fn gen_phdr_disp_name(ref auto pattern, str member_name, u8 member_index) {
     return std::format(
         "{}@phdr[{}]({})",
         member_name,
@@ -788,38 +774,39 @@ fn gen_phdr_disp_name(ref auto pattern,
 };
 
 fn main() {
-    for (u8 i = 0, i < member_count(elf.shdr), i = i + 1) {
-        if (has_member(elf.shdr[i], "stringTable")) {
-            builtin::std::core::set_dislpay_name(
+    for (u32 i = 0, i < std::core::member_count(elf.shdr), i += 1) {
+        if (std::core::has_member(elf.shdr[i], "stringTable")) {
+            std::core::set_display_name(
                 elf.shdr[i].stringTable,
                 gen_shdr_disp_name(elf.shdr[i], "stringTable", i)
             );
-            for (u64 j = 0, j < member_count(elf.shdr[i].stringTable), j = j + 1) {
-                builtin::std::core::set_dislpay_name(
+            for (u64 j = 0, j < std::core::member_count(elf.shdr[i].stringTable), j += 1) {
+                std::core::set_display_name(
                     elf.shdr[i].stringTable[j],
                     gen_shdr_sub_disp_name(elf.shdr[i], "String", i, j)
                 );
             }
-        } else if (has_member(elf.shdr[i], "symbolTable")) {
-            builtin::std::core::set_dislpay_name(
+        } else if (std::core::has_member(elf.shdr[i], "symbolTable")) {
+            std::core::set_display_name(
                 elf.shdr[i].symbolTable,
                 gen_shdr_disp_name(elf.shdr[i], "symbolTable", i)
             );
-        } else if (has_member(elf.shdr[i], "pointer")) {
-            builtin::std::core::set_dislpay_name(
+        } else if (std::core::has_member(elf.shdr[i], "pointer")) {
+            std::core::set_display_name(
                 elf.shdr[i].pointer,
                 gen_shdr_disp_name(elf.shdr[i], "pointer", i)
             );
-        } else if (has_member(elf.shdr[i], "data")) {
-            builtin::std::core::set_dislpay_name(
+        } else if (std::core::has_member(elf.shdr[i], "data")) {
+            std::core::set_display_name(
                 elf.shdr[i].data,
                 gen_shdr_disp_name(elf.shdr[i], "data", i)
             );
         }
     }
-    for (u8 i = 0, i < std::core::member_count(elf.phdr), i = i + 1) {
-        if (has_member(elf.phdr[i], "p_data")) {
-            builtin::std::core::set_dislpay_name(
+
+    for (u32 i = 0, i < std::core::member_count(elf.phdr), i += 1) {
+        if (std::core::has_member(elf.phdr[i], "p_data")) {
+            std::core::set_display_name(
                 elf.phdr[i].p_data,
                 gen_phdr_disp_name(elf.phdr[i], "p_data", i)
             );

--- a/patterns/elf.hexpat
+++ b/patterns/elf.hexpat
@@ -561,7 +561,7 @@ struct Elf32_Phdr {
     Elf32_Word p_align;
     
     if (p_offset > 0 && p_filesz > 0 && (p_offset + p_filesz) < std::mem::size() && p_filesz < std::mem::size())
-    	u8 p_data[p_filesz] @ p_offset;
+        u8 p_data[p_filesz] @ p_offset [[sealed]];
 };
 
 struct Elf64_Phdr {
@@ -575,7 +575,7 @@ struct Elf64_Phdr {
     Elf64_Xword p_align;
     
     if (p_offset > 0 && p_filesz > 0 && (p_offset + p_filesz) < std::mem::size() && p_filesz < std::mem::size())
-    	u8 p_data[p_filesz] @ p_offset;
+        u8 p_data[p_filesz] @ p_offset [[sealed]];
 };
 
 struct Elf32_Chdr {
@@ -642,7 +642,7 @@ struct Elf32_Shdr {
 		} else if (sh_type == SHT::INIT_ARRAY || sh_type == SHT::FINI_ARRAY) {
 			u32 pointer[while($ < (sh_offset + sh_size))] @ sh_offset;
 		} else {
-			u8 data[sh_size] @ sh_offset;
+			u8 data[sh_size] @ sh_offset [[sealed]];
 		}
     }
 } [[format("format_section_header")]];;
@@ -702,7 +702,7 @@ struct Elf64_Shdr {
 		} else if (sh_type == SHT::INIT_ARRAY || sh_type == SHT::FINI_ARRAY) {
 			u32 pointer[while($ < (sh_offset + sh_size))] @ sh_offset;
 		} else {
-			u8 data[sh_size] @ sh_offset;
+			u8 data[sh_size] @ sh_offset [[sealed]];
 		}
     }
 } [[format("format_section_header")]];

--- a/patterns/elf.hexpat
+++ b/patterns/elf.hexpat
@@ -4,6 +4,7 @@
 #pragma MIME application/x-object
 #pragma MIME application/x-sharedlib
 
+#include <std/io.pat>
 #include <std/core.pat>
 #include <std/mem.pat>
 
@@ -742,3 +743,86 @@ struct ELF {
 };
 
 ELF elf @ 0x00;
+
+fn member_count(ref auto pattern) {
+    return std::core::member_count(pattern);
+};
+
+fn has_member(ref auto pattern, str name) {
+    return std::core::has_member(pattern, name);
+};
+
+fn gen_shdr_disp_name(ref auto pattern,
+                    str member_name,
+                    u8 member_index) {
+    return std::format(
+        "{}@shdr[{}]({})",
+        member_name,
+        member_index,
+        format_section_header(pattern)
+    );
+};
+
+fn gen_shdr_sub_disp_name(ref auto pattern,
+                    str member_name,
+                    u8 member_index,
+                    u64 submember_index) {
+    return std::format(
+        "{}[{}]@shdr[{}]({})",
+        member_name,
+        submember_index,
+        member_index,
+        format_section_header(pattern)
+    );
+};
+
+fn gen_phdr_disp_name(ref auto pattern,
+                    str member_name,
+                    u8 member_index) {
+    return std::format(
+        "{}@phdr[{}]({})",
+        member_name,
+        member_index,
+        pattern.p_type
+    );
+};
+
+fn main() {
+    for (u8 i = 0, i < member_count(elf.shdr), i = i + 1) {
+        if (has_member(elf.shdr[i], "stringTable")) {
+            builtin::std::core::set_dislpay_name(
+                elf.shdr[i].stringTable,
+                gen_shdr_disp_name(elf.shdr[i], "stringTable", i)
+            );
+            for (u64 j = 0, j < member_count(elf.shdr[i].stringTable), j = j + 1) {
+                builtin::std::core::set_dislpay_name(
+                    elf.shdr[i].stringTable[j],
+                    gen_shdr_sub_disp_name(elf.shdr[i], "String", i, j)
+                );
+            }
+        } else if (has_member(elf.shdr[i], "symbolTable")) {
+            builtin::std::core::set_dislpay_name(
+                elf.shdr[i].symbolTable,
+                gen_shdr_disp_name(elf.shdr[i], "symbolTable", i)
+            );
+        } else if (has_member(elf.shdr[i], "pointer")) {
+            builtin::std::core::set_dislpay_name(
+                elf.shdr[i].pointer,
+                gen_shdr_disp_name(elf.shdr[i], "pointer", i)
+            );
+        } else if (has_member(elf.shdr[i], "data")) {
+            builtin::std::core::set_dislpay_name(
+                elf.shdr[i].data,
+                gen_shdr_disp_name(elf.shdr[i], "data", i)
+            );
+        }
+    }
+    for (u8 i = 0, i < std::core::member_count(elf.phdr), i = i + 1) {
+        if (has_member(elf.phdr[i], "p_data")) {
+            builtin::std::core::set_dislpay_name(
+                elf.phdr[i].p_data,
+                gen_phdr_disp_name(elf.phdr[i], "p_data", i)
+            );
+        }
+    }
+};


### PR DESCRIPTION
**DO NOT MERGE BEFORE THE CORRESPONDING PATTERN LANGUAGE PULL REQUEST**
https://github.com/WerWolv/PatternLanguage/pull/29

## Problem statement:

Since ELF file has ~30 sections and ~8 segments all with similar structures, it gets very ambiguous in Hex Editor view:

<img width="528" alt="Screenshot 2023-02-26 at 17 15 29" src="https://user-images.githubusercontent.com/6459910/221425706-c0fee27e-3b67-4686-bb28-892ede6463f9.png">

What section/segment do each of `p_data` and `data` belong to?
To figure it out the ImHex user ends up jumping back and forth between Hex Editor and Pattern Data views and clicking to expand each section/segment header as they are not highlighted when you highlight some byte in Hex Editor view.

## Proposed Solution:

We add a post processing step to set the display names for all data data arrays to the notations that mention both section index and name, index and type for segments. Unfortunately it has to be a post processing step as string table with all of the names is also one of the sections. Not even close to being the first one.
Result:

![hover_over_hex_ELF](https://user-images.githubusercontent.com/6459910/221425070-c48c6f2a-96d2-453c-b33f-4ebd97305ed4.gif)

P.S. Sorry if my pattern script is a bit clunky, i am ready to improve it with your guidance :)

P.P.S A more complicated alternative to it will be making `pl::ptrn::Pattern` store the reference to its parent and show the path from pattern node to root pattern in pattern tooltip view, but it will be less flexible.

