### PR TITLE
add more information to display for dex pattern

### DIFF
--- a/patterns/dex.hexpat
+++ b/patterns/dex.hexpat
@@ -16,8 +16,8 @@ struct header_item {
     u32 type_ids_off;
     u32 proto_ids_size;
     u32 proto_ids_off;
-    u32 file_ids_size;
-    u32 file_ids_off;
+    u32 field_ids_size;
+    u32 field_ids_off;
     u32 method_ids_size;
     u32 method_ids_off;
     u32 class_defs_size;
@@ -38,47 +38,47 @@ struct map_list {
     map_item list[size];
 };
 
-struct string_id_item {
-    u32 string_data_off;
-};
-
 struct string_data_item {
-    type::uLEB128 utf16_size;
-    u8 data[utf16_size];
-};
+    type::uLEB128 utf16_size[[hidden]];
+    char string[utf16_size];
+}[[inline]];
+
+struct string_id_item {
+    string_data_item* string_data: u32;
+}[[name(string_data.string)]];
+
 
 struct type_id_item {
     u32 descriptor_idx;
-};
+    char type_name[] @ addressof(parent.string_ids[descriptor_idx].string_data.string);
+}[[name(type_name)]];
 
 struct proto_id_item {
     u32 shorty_idx;
     u32 return_type_idx;
     u32 parameters_off;
-};
+    char shorty_dec[] @ addressof(parent.string_ids[shorty_idx].string_data.string);
+    char return_type[] @ addressof(parent.type_ids[return_type_idx].type_name);
+}[[name(shorty_dec)]];
 
 struct field_id_item {
     u16 class_idx;
     u16 type_idx;
     u32 name_idx;
-};
+    char class_name[] @ addressof(parent.type_ids[class_idx].type_name);
+    char type_name[] @ addressof(parent.type_ids[type_idx].type_name);
+    char field_name[] @ addressof(parent.string_ids[name_idx].string_data.string);
+}[[name(field_name)]];
 
 struct method_id_item {
     u16 class_idx;
     u16 proto_idx;
     u32 name_idx;
-};
+    char class_name[] @ addressof(parent.type_ids[class_idx].type_name);
+    char proto_desc[] @ addressof(parent.proto_ids[proto_idx].shorty_dec);
+    char method_name[] @ addressof(parent.string_ids[name_idx].string_data.string);
 
-struct class_def_item {
-    u32 class_idx;
-    u32 access_flags;
-    u32 superclass_idx;
-    u32 interfaces_off;
-    u32 source_file_idx;
-    u32 annotations_off;
-    u32 class_data_off;
-    u32 static_values_off;
-};
+}[[name(class_name+method_name)]];
 
 struct class_site_id_item {
     u32 call_site_off;
@@ -90,10 +90,19 @@ struct method_handle_item {
     u16 field_or_method_id;
     u16 unused2;
 };
+enum access_flag : type::uLEB128{
+    public = 0x1,
+    private = 0x2,
+    protected = 0x4,
+    static = 0x8,
+    final = 0x10,
+    synchronized = 0x20,
+    volatile = 0x40    
+};
 
 struct encoded_field {
     type::uLEB128 field_idx_diff;
-    type::uLEB128 access_flags;
+    access_flag access_flags;
 };
 
 struct encoded_method {
@@ -112,6 +121,19 @@ struct class_data_item {
     encoded_method direct_methods[direct_methods_size];
     encoded_method virtual_methods[virtual_methods_size];
 };
+
+struct class_def_item {
+    u32 class_idx;
+    u32 access_flags;
+    u32 superclass_idx;
+    u32 interfaces_off;
+    u32 source_file_idx;
+    u32 annotations_off;
+    u32 class_data_off;
+    //class_data_item *class_data_off:u32;
+    u32 static_values_off;
+    char class_name[] @ addressof(parent.type_ids[class_idx].type_name);    
+}[[name(class_name)]];
 
 struct type_item {
     u16 type_idx;
@@ -142,12 +164,11 @@ struct try_item {
 
 struct Dex {
     header_item header;
-    string_id_item string_ids[header.string_ids_size];
-    type_id_item type_ids[header.type_ids_size];
-    proto_id_item proto_ids[header.proto_ids_size];
-    field_id_item field_ids[header.file_ids_size];
-    method_id_item method_ids[header.method_ids_size];
-    class_def_item class_defs[header.class_defs_size];
+    string_id_item string_ids[header.string_ids_size] @ header.string_ids_off;
+    type_id_item type_ids[header.type_ids_size] @ header.type_ids_off;
+    proto_id_item proto_ids[header.proto_ids_size] @ header.proto_ids_off;
+    field_id_item field_ids[header.field_ids_size] @ header.field_ids_off;
+    method_id_item method_ids[header.method_ids_size] @ header.method_ids_off;
+    class_def_item class_defs[header.class_defs_size] @ header.class_defs_off;
 };
 Dex dex @ 0x00;
-string_data_item string_data_item_at_0x1AA @ 0x1AA;


### PR DESCRIPTION
Added string representations for:
- string ids
- field ids
- method ids
- class ids
- proto ids

Example display:

![Screenshot_85](https://user-images.githubusercontent.com/21275072/224514576-e7dbafba-279f-488f-bba9-ea656a632664.png)

I left the `class_data_item *class_data_off:u32;` line commented out because it increases parsing time so much. In my test dex sample 0.5 to 3.5 seconds

