### PR TITLE
Add nullable pointers to std/ptr

### DIFF
--- a/includes/std/ptr.pat
+++ b/includes/std/ptr.pat
@@ -34,4 +34,34 @@ namespace std::ptr {
         return std::mem::size() - offset * 2;
     };
 
+    /**
+    A nullable pointer, generic over both the pointee type and pointer type.
+
+    By nullable, we mean that if the pointer's value is zero (`0x0`), then the
+    value will appear as padding rather than a pointer to something, but
+    if the pointer's value is non-zero, that non-zero value will be treated as
+    a pointer of type `PointerTy` which points to an element of type `PointeeTy`.
+
+    Example:
+    A struct field called `p_myInfo` which is a nullable 64-bit pointer to an
+    element of type `MyInfoTy` would be written as:
+    ```
+    struct MyStruct {
+      std::ptr::NullablePtr<MyInfoTy, u64> p_myInfo;
+    }
+    ```
+    */
+    struct NullablePtr<PointeeTy, PointerTy> {
+        // `pointerValue` is `no_unique_address` because we don't want to advance
+        // the current memory location after reading the value of the pointer itself;
+        // we want to examine the value at this address to determine what should be
+        // displayed. It's also `hidden` so the editor only displays either thee 
+        // padding or the populated pointer/pointee field.
+        PointerTy pointerValue [[no_unique_address, hidden]];
+        if (pointerValue == 0x0) {
+            padding[sizeof(PointerTy)];
+        } else {
+            PointeeTy *data : PointerTy;
+        }
+    };
 }


### PR DESCRIPTION
An implementation of nullable pointers was discussed briefly on discord; WerWolv suggested the implementation in the example code here that's ostensibly generic over the pointer type/size, but the template system doesn't seem to like this special case where a type argument is used as a pointer type (the code below returns the error `Pointer size needs to be a built-in type`, with the error being directed at `T *data : Size;`):

```
struct NullablePtr<T, Size> {
    Size pointerValue [[no_unique_address, hidden]];
    if (pointerValue == 0x0) {
        padding[sizeof(Size)];
    } else {
        T *data : Size;
    }
};
```

So I specialized the structure to the common 2^n pointer types. I'll leave it up to WerWolv /  maintainers whether they want to use this specialized version, do something else, or just forego adding this as a feature and instead document it as a "user pattern" in the manual or something.