### PR TITLE
patterns: put author and description inside each pattern

### DIFF
--- a/patterns/3ds.hexpat
+++ b/patterns/3ds.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Autodesk 3DS Max Model file
 
 #include <std/io.pat>

--- a/patterns/3ds.hexpat
+++ b/patterns/3ds.hexpat
@@ -1,3 +1,5 @@
+#pragma description Autodesk 3DS Max Model file
+
 #include <std/io.pat>
 #include <type/base.pat>
 

--- a/patterns/7z.hexpat
+++ b/patterns/7z.hexpat
@@ -1,3 +1,5 @@
+#pragma description 7z File Format
+
 #include <std/io.pat> 
 #include <std/mem.pat> 
 #include <std/math.pat> 

--- a/patterns/Crashlvl.hexpat
+++ b/patterns/Crashlvl.hexpat
@@ -1,3 +1,5 @@
+#pragma description Crash Bandicoot - Back in Time (fan game) User created flashback tapes level format
+
 #include <type/magic.pat>
 #include <std/string.pat>
 #include <std/array.pat>

--- a/patterns/afe2.hexpat
+++ b/patterns/afe2.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Nintendo Switch Atmosphère CFW Fatal Error log
 
 #pragma endian little

--- a/patterns/afe2.hexpat
+++ b/patterns/afe2.hexpat
@@ -1,3 +1,5 @@
+#pragma description Nintendo Switch Atmosphère CFW Fatal Error log
+
 #pragma endian little
 
 #include <std/io.pat>

--- a/patterns/ar.hexpat
+++ b/patterns/ar.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Static library archive files
 
 #pragma MIME application/x-archive

--- a/patterns/ar.hexpat
+++ b/patterns/ar.hexpat
@@ -1,3 +1,5 @@
+#pragma description Static library archive files
+
 #pragma MIME application/x-archive
 
 #include <std/string.pat>

--- a/patterns/arm_cm_vtor.hexpat
+++ b/patterns/arm_cm_vtor.hexpat
@@ -1,3 +1,5 @@
+#pragma description ARM Cortex M Vector Table Layout
+
 #pragma endian little
 
 #include <std/io.pat>

--- a/patterns/arm_cm_vtor.hexpat
+++ b/patterns/arm_cm_vtor.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description ARM Cortex M Vector Table Layout
 
 #pragma endian little

--- a/patterns/bencode.hexpat
+++ b/patterns/bencode.hexpat
@@ -1,3 +1,5 @@
+#pragma description Bencode encoding, used by Torrent files
+
 #pragma MIME application/x-bittorrent
 
 #include <std/ctype.pat>

--- a/patterns/bencode.hexpat
+++ b/patterns/bencode.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Bencode encoding, used by Torrent files
 
 #pragma MIME application/x-bittorrent

--- a/patterns/bmp.hexpat
+++ b/patterns/bmp.hexpat
@@ -1,3 +1,5 @@
+#pragma description OS2/Windows Bitmap files
+
 #pragma MIME image/bmp
 #pragma endian little
 #include <std/mem.pat>

--- a/patterns/bson.hexpat
+++ b/patterns/bson.hexpat
@@ -1,3 +1,5 @@
+#pragma description BSON (Binary JSON) format
+
 #pragma MIME application/bson
 
 #include <type/time.pat>

--- a/patterns/bson.hexpat
+++ b/patterns/bson.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description BSON (Binary JSON) format
 
 #pragma MIME application/bson

--- a/patterns/bsp_goldsrc.hexpat
+++ b/patterns/bsp_goldsrc.hexpat
@@ -1,3 +1,5 @@
+#pragma description GoldSrc engine maps format (used in Half-Life 1)
+
 #include <std/ptr.pat>
 #include <std/mem.pat>
 #include <std/sys.pat>

--- a/patterns/cchva.hexpat
+++ b/patterns/cchva.hexpat
@@ -1,3 +1,5 @@
+#pragma description Command and Conquer Voxel Animation
+
 // Command and conquer voxel animation format
 
 struct vec4_s {

--- a/patterns/ccpal.hexpat
+++ b/patterns/ccpal.hexpat
@@ -1,3 +1,5 @@
+#pragma description Command and Conquer Voxel Palette
+
 // Command and conquer palette format
 
 struct Color {

--- a/patterns/ccvxl.hexpat
+++ b/patterns/ccvxl.hexpat
@@ -1,3 +1,5 @@
+#pragma description Command and Conquer Voxel Model
+
 // Command and Conquer voxel model format
 
 struct vec4_s {

--- a/patterns/cda.hexpat
+++ b/patterns/cda.hexpat
@@ -1,3 +1,5 @@
+#pragma description Compact Disc Audio track
+
 struct Header {
 u32 RIFF;
 s32 size;

--- a/patterns/chm.hexpat
+++ b/patterns/chm.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Windows HtmlHelp Data (ITSF / CHM)
 
 #include <type/magic.pat>

--- a/patterns/chm.hexpat
+++ b/patterns/chm.hexpat
@@ -1,3 +1,5 @@
+#pragma description Windows HtmlHelp Data (ITSF / CHM)
+
 #include <type/magic.pat>
 #include <type/size.pat>
 #include <type/guid.pat>

--- a/patterns/coff.hexpat
+++ b/patterns/coff.hexpat
@@ -1,3 +1,5 @@
+#pragma description Common Object File Format (COFF) executable
+
 #pragma MIME application/x-coff
 
 #include <type/time.pat>

--- a/patterns/coff.hexpat
+++ b/patterns/coff.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Common Object File Format (COFF) executable
 
 #pragma MIME application/x-coff

--- a/patterns/cpio.hexpat
+++ b/patterns/cpio.hexpat
@@ -1,3 +1,5 @@
+#pragma description Old Binary CPIO Format
+
 #include <type/base.pat>
 
 #include <std/time.pat>

--- a/patterns/cpio.hexpat
+++ b/patterns/cpio.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Old Binary CPIO Format
 
 #include <type/base.pat>

--- a/patterns/dds.hexpat
+++ b/patterns/dds.hexpat
@@ -1,3 +1,5 @@
+#pragma description DirectDraw Surface
+
 #pragma MIME image/vnd-ms.dds
 #pragma endian little
 

--- a/patterns/dex.hexpat
+++ b/patterns/dex.hexpat
@@ -1,3 +1,5 @@
+#pragma description Dalvik EXecutable Format
+
 #include <type/leb128.pat>
 
 struct header_item {

--- a/patterns/dmg.hexpat
+++ b/patterns/dmg.hexpat
@@ -1,3 +1,5 @@
+#pragma description Apple Disk Image Trailer (DMG)
+
 #pragma endian big
 
 #include <type/magic.pat>

--- a/patterns/dsstore.hexpat
+++ b/patterns/dsstore.hexpat
@@ -1,3 +1,5 @@
+#pragma description .DS_Store file format
+
 // Apple macOS .DS_Store format
 #pragma endian big
 #include <std/io.pat>

--- a/patterns/elf.hexpat
+++ b/patterns/elf.hexpat
@@ -1,3 +1,5 @@
+#pragma description ELF header in elf binaries
+
 #pragma MIME application/x-executable
 #pragma MIME application/x-elf
 #pragma MIME application/x-coredump

--- a/patterns/elf.hexpat
+++ b/patterns/elf.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description ELF header in elf binaries
 
 #pragma MIME application/x-executable

--- a/patterns/evtx.hexpat
+++ b/patterns/evtx.hexpat
@@ -1,3 +1,5 @@
+#pragma description MS Windows Vista Event Log
+
 #pragma endian little
 
 struct Header {

--- a/patterns/fdt.hexpat
+++ b/patterns/fdt.hexpat
@@ -1,3 +1,5 @@
+#pragma description Flat Linux Device Tree blob
+
 #pragma endian big
 
 #include <std/sys.pat>

--- a/patterns/fdt.hexpat
+++ b/patterns/fdt.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Flat Linux Device Tree blob
 
 #pragma endian big

--- a/patterns/flac.hexpat
+++ b/patterns/flac.hexpat
@@ -1,3 +1,5 @@
+#pragma description Free Lossless Audio Codec, FLAC Audio Format
+
 #include <std/sys.pat>
 #include <std/core.pat>
 #include <std/io.pat>

--- a/patterns/flac.hexpat
+++ b/patterns/flac.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Free Lossless Audio Codec, FLAC Audio Format
 
 #include <std/sys.pat>

--- a/patterns/fs.hexpat
+++ b/patterns/fs.hexpat
@@ -1,3 +1,5 @@
+#pragma description Drive File System
+
 #include <std/io.pat>
 
 struct DiskTimeStamp {

--- a/patterns/fs.hexpat
+++ b/patterns/fs.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Drive File System
 
 #include <std/io.pat>

--- a/patterns/gb.hexpat
+++ b/patterns/gb.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Gameboy ROM
 
 #include <type/size.pat>

--- a/patterns/gb.hexpat
+++ b/patterns/gb.hexpat
@@ -1,3 +1,5 @@
+#pragma description Gameboy ROM
+
 #include <type/size.pat>
 #include <std/io.pat>
 #include <std/string.pat>

--- a/patterns/gif.hexpat
+++ b/patterns/gif.hexpat
@@ -1,3 +1,5 @@
+#pragma description GIF image files
+
 #pragma MIME image/gif
 
 // Extension Labels

--- a/patterns/gzip.hexpat
+++ b/patterns/gzip.hexpat
@@ -1,3 +1,5 @@
+#pragma description GZip compressed data format
+
 #pragma MIME application/gzip
 
 #include <type/time.pat>

--- a/patterns/gzip.hexpat
+++ b/patterns/gzip.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description GZip compressed data format
 
 #pragma MIME application/gzip

--- a/patterns/ico.hexpat
+++ b/patterns/ico.hexpat
@@ -1,3 +1,5 @@
+#pragma description Icon (.ico) or Cursor (.cur) files
+
 #pragma endian little
 
 #include <std/sys.pat>

--- a/patterns/ico.hexpat
+++ b/patterns/ico.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Icon (.ico) or Cursor (.cur) files
 
 #pragma endian little

--- a/patterns/id3.hexpat
+++ b/patterns/id3.hexpat
@@ -1,3 +1,5 @@
+#pragma description ID3 tags in MP3 files
+
 #pragma MIME audio/mpeg
 
 #include <std/mem.pat>

--- a/patterns/intel_hex.hexpat
+++ b/patterns/intel_hex.hexpat
@@ -1,3 +1,5 @@
+#pragma description [Intel hexadecimal object file format definition]("https://en.wikipedia.org/wiki/Intel_HEX")
+
 /* If you have no delimiters between data records then remove 
  * the null_bytes field in the data_packet struct.
  * Set the array at the bottom to the highest index + 1 in the Pattern Data view

--- a/patterns/ip.hexpat
+++ b/patterns/ip.hexpat
@@ -1,3 +1,5 @@
+#pragma description Ethernet II Frames (IP Packets)
+
  #pragma endian big
 
 #include <std/sys.pat>

--- a/patterns/ip.hexpat
+++ b/patterns/ip.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Ethernet II Frames (IP Packets)
 
  #pragma endian big

--- a/patterns/ips.hexpat
+++ b/patterns/ips.hexpat
@@ -1,3 +1,5 @@
+#pragma description IPS (International Patching System) files
+
 #include <std/mem.pat>
 #include <std/string.pat>
 

--- a/patterns/iso.hexpat
+++ b/patterns/iso.hexpat
@@ -1,3 +1,5 @@
+#pragma description ISO 9660 file system
+
 #pragma endian little
 
 #include <std/io.pat>

--- a/patterns/java_class.hexpat
+++ b/patterns/java_class.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Java Class files
 
 #pragma endian big

--- a/patterns/java_class.hexpat
+++ b/patterns/java_class.hexpat
@@ -1,3 +1,5 @@
+#pragma description Java Class files
+
 #pragma endian big
 #pragma pattern_limit 100000000
 #pragma MIME application/x-java-applet

--- a/patterns/jpeg.hexpat
+++ b/patterns/jpeg.hexpat
@@ -1,3 +1,5 @@
+#pragma description JPEG Image Format
+
 #include <std/mem.pat>
 #pragma endian big
 

--- a/patterns/jpeg.hexpat
+++ b/patterns/jpeg.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description JPEG Image Format
 
 #include <std/mem.pat>

--- a/patterns/lnk.hexpat
+++ b/patterns/lnk.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Windows Shell Link file format
 
 #pragma MIME application/x-ms-shortcut

--- a/patterns/lnk.hexpat
+++ b/patterns/lnk.hexpat
@@ -1,3 +1,5 @@
+#pragma description Windows Shell Link file format
+
 #pragma MIME application/x-ms-shortcut
 
 #include <std/core.pat>

--- a/patterns/lua54.hexpat
+++ b/patterns/lua54.hexpat
@@ -1,3 +1,5 @@
+#pragma description Lua 5.4 bytecode
+
 #include <std/io.pat>
 #include <std/mem.pat>
 

--- a/patterns/macho.hexpat
+++ b/patterns/macho.hexpat
@@ -1,3 +1,5 @@
+#pragma description Mach-O executable
+
 #pragma MIME application/x-mach-binary
 
 #include <type/size.pat>

--- a/patterns/macho.hexpat
+++ b/patterns/macho.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Mach-O executable
 
 #pragma MIME application/x-mach-binary

--- a/patterns/max_v104.hexpat
+++ b/patterns/max_v104.hexpat
@@ -1,3 +1,5 @@
+#pragma description Mechanized Assault and Exploration v1.04 (strategy game) save file format
+
 #include <std/sys.pat>
 #include <std/mem.pat>
 

--- a/patterns/midi.hexpat
+++ b/patterns/midi.hexpat
@@ -1,3 +1,5 @@
+#pragma description MIDI header, event fields provided
+
 #include <std/core.pat>
 
 #pragma MIME audio/midi

--- a/patterns/minidump.hexpat
+++ b/patterns/minidump.hexpat
@@ -1,3 +1,5 @@
+#pragma description Windows MiniDump files
+
 #pragma MIME application/x-dmp
 
 #include <type/time.pat>

--- a/patterns/minidump.hexpat
+++ b/patterns/minidump.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Windows MiniDump files
 
 #pragma MIME application/x-dmp

--- a/patterns/mp4.hexpat
+++ b/patterns/mp4.hexpat
@@ -1,3 +1,5 @@
+#pragma description MPEG-4 Part 14 digital multimedia container format
+
 #pragma endian big
 
 #pragma MIME audio/mp4

--- a/patterns/msgpack.hexpat
+++ b/patterns/msgpack.hexpat
@@ -1,3 +1,5 @@
+#pragma description MessagePack binary serialization format
+
 #pragma MIME application/x-msgpack
 
 enum Type : u8 {

--- a/patterns/msgpack.hexpat
+++ b/patterns/msgpack.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description MessagePack binary serialization format
 
 #pragma MIME application/x-msgpack

--- a/patterns/nacp.hexpat
+++ b/patterns/nacp.hexpat
@@ -1,3 +1,5 @@
+#pragma description Nintendo Switch NACP files
+
 #pragma endian little
 
 #include <std/sys.pat>

--- a/patterns/nacp.hexpat
+++ b/patterns/nacp.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Nintendo Switch NACP files
 
 #pragma endian little

--- a/patterns/nbt.hexpat
+++ b/patterns/nbt.hexpat
@@ -1,3 +1,5 @@
+#pragma description Minecraft NBT format
+
 #include <std/sys.pat>
 
 #pragma endian big

--- a/patterns/nbt.hexpat
+++ b/patterns/nbt.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Minecraft NBT format
 
 #include <std/sys.pat>

--- a/patterns/ne.hexpat
+++ b/patterns/ne.hexpat
@@ -1,3 +1,5 @@
+#pragma description NE header and Standard NE fields
+
 #include <std/mem.pat>
 
 struct DOSHeader {

--- a/patterns/nro.hexpat
+++ b/patterns/nro.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Nintendo Switch NRO files
 
 #include <std/io.pat>

--- a/patterns/nro.hexpat
+++ b/patterns/nro.hexpat
@@ -1,3 +1,5 @@
+#pragma description Nintendo Switch NRO files
+
 #include <std/io.pat>
 #include <std/sys.pat>
 

--- a/patterns/ntag.hexpat
+++ b/patterns/ntag.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description NTAG213/NTAG215/NTAG216, NFC Forum Type 2 Tag compliant IC
 
 #include <std/core.pat>

--- a/patterns/ntag.hexpat
+++ b/patterns/ntag.hexpat
@@ -1,3 +1,5 @@
+#pragma description NTAG213/NTAG215/NTAG216, NFC Forum Type 2 Tag compliant IC
+
 #include <std/core.pat>
 
 using BitfieldOrder = std::core::BitfieldOrder;

--- a/patterns/ogg.hexpat
+++ b/patterns/ogg.hexpat
@@ -1,3 +1,5 @@
+#pragma description OGG Audio format
+
 #pragma MIME audio/ogg
 
 #include <std/core.pat>

--- a/patterns/ogg.hexpat
+++ b/patterns/ogg.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description OGG Audio format
 
 #pragma MIME audio/ogg

--- a/patterns/pcap.hexpat
+++ b/patterns/pcap.hexpat
@@ -1,3 +1,5 @@
+#pragma description pcap header and packets
+
 #include <std/mem.pat>
 #pragma MIME application/vnd.tcpdump.pcap
 

--- a/patterns/pcx.hexpat
+++ b/patterns/pcx.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description PCX Image format
 
 #pragma MIME application/x-pcx

--- a/patterns/pcx.hexpat
+++ b/patterns/pcx.hexpat
@@ -1,3 +1,5 @@
+#pragma description PCX Image format
+
 #pragma MIME application/x-pcx
 
 #include <std/io.pat>

--- a/patterns/pe.hexpat
+++ b/patterns/pe.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description PE header, COFF header, Standard COFF fields and Windows Specific fields
 
 #pragma MIME application/x-dosexec

--- a/patterns/pe.hexpat
+++ b/patterns/pe.hexpat
@@ -1,3 +1,5 @@
+#pragma description PE header, COFF header, Standard COFF fields and Windows Specific fields
+
 #pragma MIME application/x-dosexec
 #pragma MIME application/x-msdownload
 

--- a/patterns/pfs0.hexpat
+++ b/patterns/pfs0.hexpat
@@ -1,3 +1,5 @@
+#pragma description Nintendo Switch PFS0 archive (NSP files)
+
 #include <type/magic.pat>
 #include <type/size.pat>
 

--- a/patterns/pfs0.hexpat
+++ b/patterns/pfs0.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Nintendo Switch PFS0 archive (NSP files)
 
 #include <type/magic.pat>

--- a/patterns/pif.hexpat
+++ b/patterns/pif.hexpat
@@ -1,3 +1,5 @@
+#pragma description PIF Image Format
+
 /* PIF - Portable Image Format
  *
  * Basic decoder for the PIF file structure

--- a/patterns/png.hexpat
+++ b/patterns/png.hexpat
@@ -1,3 +1,5 @@
+#pragma description PNG image files 
+
 #pragma MIME image/png
 #pragma endian big
 

--- a/patterns/prodinfo.hexpat
+++ b/patterns/prodinfo.hexpat
@@ -1,3 +1,5 @@
+#pragma description Nintendo Switch PRODINFO 
+
 enum Model : u16 {
 	NX = 1
 };

--- a/patterns/prodinfo.hexpat
+++ b/patterns/prodinfo.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Nintendo Switch PRODINFO 
 
 enum Model : u16 {

--- a/patterns/protobuf.hexpat
+++ b/patterns/protobuf.hexpat
@@ -1,3 +1,5 @@
+#pragma description Google Protobuf encoding 
+
 #include <std/core.pat>
 #include <std/mem.pat>
 

--- a/patterns/protobuf.hexpat
+++ b/patterns/protobuf.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Google Protobuf encoding 
 
 #include <std/core.pat>

--- a/patterns/pyc.hexpat
+++ b/patterns/pyc.hexpat
@@ -1,3 +1,5 @@
+#pragma description Python bytecode files
+
 #include <type/time.pat>
 #include <std/mem.pat>
 

--- a/patterns/pyinstaller.hexpat
+++ b/patterns/pyinstaller.hexpat
@@ -1,3 +1,5 @@
+#pragma description PyInstaller binray files 
+
 #pragma endian big
 
 #include <std/mem.pat>

--- a/patterns/qbcl.hexpat
+++ b/patterns/qbcl.hexpat
@@ -1,3 +1,5 @@
+#pragma description Qubicle voxel scene project file
+
 // Qubicle QBCL format
 
 struct String {

--- a/patterns/qoi.hexpat
+++ b/patterns/qoi.hexpat
@@ -1,3 +1,5 @@
+#pragma description QOI image files
+
 #pragma MIME image/qoi
 #pragma endian big
 

--- a/patterns/selinux.hexpat
+++ b/patterns/selinux.hexpat
@@ -1,3 +1,5 @@
+#pragma description SE Linux modules
+
 #include <std/sys.pat>
 #pragma pattern_limit 13107200
 #pragma endian little

--- a/patterns/selinuxpp.hexpat
+++ b/patterns/selinuxpp.hexpat
@@ -1,3 +1,5 @@
+#pragma description SE Linux package
+
 // SE Linux Policy Package
 // Extension: PP
 // https://github.com/SELinuxProject/selinux/blob/master/libsepol/src/module.c

--- a/patterns/sit5.hexpat
+++ b/patterns/sit5.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description StuffIt V5 archive
 
 // Based on https://github.com/mietek/theunarchiver/wiki/StuffIt5Format and https://github.com/ParksProjets/Maconv/blob/master/docs/stuffit/Stuffit_v5.md

--- a/patterns/sit5.hexpat
+++ b/patterns/sit5.hexpat
@@ -1,3 +1,5 @@
+#pragma description StuffIt V5 archive
+
 // Based on https://github.com/mietek/theunarchiver/wiki/StuffIt5Format and https://github.com/ParksProjets/Maconv/blob/master/docs/stuffit/Stuffit_v5.md
 
 #pragma endian big

--- a/patterns/spirv.hexpat
+++ b/patterns/spirv.hexpat
@@ -1,3 +1,5 @@
+#pragma description SPIR-V header and instructions
+
 #include <std/mem.pat>
 
 enum GeneratorID : u16 {

--- a/patterns/stl.hexpat
+++ b/patterns/stl.hexpat
@@ -1,3 +1,5 @@
+#pragma description STL 3D Model format
+
 #pragma MIME model/stl
 #pragma MIME model/x.stl-binary
 #pragma MIME model/x.stl-ascii

--- a/patterns/stl.hexpat
+++ b/patterns/stl.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description STL 3D Model format
 
 #pragma MIME model/stl

--- a/patterns/tar.hexpat
+++ b/patterns/tar.hexpat
@@ -1,3 +1,5 @@
+#pragma description Tar file format
+
 #pragma MIME application/tar
 #pragma MIME application/x-tar
 

--- a/patterns/tga.hexpat
+++ b/patterns/tga.hexpat
@@ -1,3 +1,5 @@
+#pragma description Truevision TGA/TARGA image
+
 #pragma MIME image/tga
 #pragma endian little
 

--- a/patterns/tiff.hexpat
+++ b/patterns/tiff.hexpat
@@ -1,3 +1,5 @@
+#pragma description Tag Image File Format
+
 #pragma MIME image/tiff
 
 #pragma eval_depth 100

--- a/patterns/ubiquiti.hexpat
+++ b/patterns/ubiquiti.hexpat
@@ -1,3 +1,5 @@
+#pragma description Ubiquiti Firmware (update) image
+
 #pragma endian big
 
 #include <std/mem.pat>

--- a/patterns/uefi.hexpat
+++ b/patterns/uefi.hexpat
@@ -1,3 +1,5 @@
+#pragma description UEFI structs for parsing efivars
+
 #pragma MIME data
 
 #define WIN_CERT_TYPE_PKCS_SIGNED_DATA 0x0002

--- a/patterns/uf2.hexpat
+++ b/patterns/uf2.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description [USB Flashing Format](https://github.com/microsoft/uf2)
 
 #include <std/sys.pat>

--- a/patterns/uf2.hexpat
+++ b/patterns/uf2.hexpat
@@ -1,3 +1,5 @@
+#pragma description [USB Flashing Format](https://github.com/microsoft/uf2)
+
 #include <std/sys.pat>
 #include <std/mem.pat>
 

--- a/patterns/vdf.hexpat
+++ b/patterns/vdf.hexpat
@@ -1,3 +1,5 @@
+#pragma description Binary Value Data Format (.vdf) files
+
 #pragma eval_depth 0x10000
 
 #include <std/mem.pat>

--- a/patterns/vdf.hexpat
+++ b/patterns/vdf.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Binary Value Data Format (.vdf) files
 
 #pragma eval_depth 0x10000

--- a/patterns/vhdx.hexpat
+++ b/patterns/vhdx.hexpat
@@ -1,3 +1,5 @@
+#pragma description Microsoft Hyper-V Virtual Hard Disk format
+
 #include <std/io.pat>
 #include <std/ptr.pat>
 #include <std/core.pat>

--- a/patterns/vhdx.hexpat
+++ b/patterns/vhdx.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Microsoft Hyper-V Virtual Hard Disk format
 
 #include <std/io.pat>

--- a/patterns/wad.hexpat
+++ b/patterns/wad.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description DOOM WAD Archive
 
 #include <type/magic.pat>

--- a/patterns/wad.hexpat
+++ b/patterns/wad.hexpat
@@ -1,3 +1,5 @@
+#pragma description DOOM WAD Archive
+
 #include <type/magic.pat>
 #include <type/size.pat>
 

--- a/patterns/wav.hexpat
+++ b/patterns/wav.hexpat
@@ -1,3 +1,5 @@
+#pragma description RIFF header, WAVE header, PCM header
+
 #pragma MIME audio/x-wav
 #pragma MIME audio/wav
 

--- a/patterns/xbeh.hexpat
+++ b/patterns/xbeh.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Xbox executable
 
 #pragma MIME audio/x-xbox-executable

--- a/patterns/xbeh.hexpat
+++ b/patterns/xbeh.hexpat
@@ -1,3 +1,5 @@
+#pragma description Xbox executable
+
 #pragma MIME audio/x-xbox-executable
 
 #include <type/magic.pat>

--- a/patterns/xci.hexpat
+++ b/patterns/xci.hexpat
@@ -1,3 +1,5 @@
+#pragma description Nintendo Switch XCI cardridge ROM
+
 #include <std/core.pat>
 
 #include <type/magic.pat>

--- a/patterns/xci.hexpat
+++ b/patterns/xci.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Nintendo Switch XCI cardridge ROM
 
 #include <std/core.pat>

--- a/patterns/xilinx_bit.hexpat
+++ b/patterns/xilinx_bit.hexpat
@@ -1,3 +1,4 @@
+#pragma author WerWolv
 #pragma description Xilinx FPGA Bitstreams
 
 #include <std/mem.pat>

--- a/patterns/xilinx_bit.hexpat
+++ b/patterns/xilinx_bit.hexpat
@@ -1,3 +1,5 @@
+#pragma description Xilinx FPGA Bitstreams
+
 #include <std/mem.pat>
 #include <std/io.pat>
 

--- a/patterns/zip.hexpat
+++ b/patterns/zip.hexpat
@@ -1,3 +1,5 @@
+#pragma description End of Central Directory Header, Central Directory File Headers
+
 #pragma MIME application/zip
 
 #include <std/mem.pat>

--- a/patterns/zlib.hexpat
+++ b/patterns/zlib.hexpat
@@ -1,3 +1,5 @@
+#pragma description ZLIB compressed data format
+
 #pragma MIME application/zlib
 
 #include <std/core.pat>

--- a/patterns/zstd.hexpat
+++ b/patterns/zstd.hexpat
@@ -1,3 +1,5 @@
+#pragma description Zstandard compressed data format
+
 // https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md
 
 #pragma MIME application/zstd


### PR DESCRIPTION
Title is self-explanatory

Proposition I need your approval for: remove the patterns table in the README, to avoid having to maintain two copy of the same information, and avoid risking people only putting the description in the table and forget to use `#pragma` in their file