### PR TITLE
BSON support for multiple documents per file

### DIFF
--- a/patterns/bson.hexpat
+++ b/patterns/bson.hexpat
@@ -1,3 +1,6 @@
+#pragma author WerWolv
+#pragma description BSON (Binary JSON) format
+
 #pragma MIME application/bson
 
 #include <std/mem.pat>

--- a/patterns/bson.hexpat
+++ b/patterns/bson.hexpat
@@ -1,8 +1,6 @@
-#pragma author WerWolv
-#pragma description BSON (Binary JSON) format
-
 #pragma MIME application/bson
 
+#include <std/mem.pat>
 #include <type/time.pat>
 
 enum Type : u8 {
@@ -128,4 +126,4 @@ struct Document {
     padding[1];
 };
 
-Document document @ 0x00;
+Document documents[while(!std::mem::eof())] @ 0x00 [[inline]];


### PR DESCRIPTION
BSON files can contain consecutive documents glued one after another. An example of these is MongoDB FTDC metrics export.

[`bsondump`](https://github.com/mongodb/mongo-tools/blob/master/bsondump/bsondump.go) can unpack this type of BSON documents.
