### PR TITLE
patterns/id3: Fix the error `No variable named 'n' found.`

### DIFF
--- a/patterns/id3.hexpat
+++ b/patterns/id3.hexpat
@@ -26,10 +26,10 @@ namespace v2 {
         u8 bytes[4];
     } [[sealed, static, format("v2::ssi_value"), transform("v2::ssi_value")]];
 
-    fn ssi_value(ref SyncSafeInt n) {
+    fn ssi_value(ref SyncSafeInt size) {
         u32 result = 0;
         for (u8 i = 0, i < 4, i = i + 1) {
-            u8 byteval = n.bytes[i] & 0x7F;
+            u8 byteval = size.bytes[i] & 0x7F;
             u8 shift = 7 * (4 - i - 1);
             result = result | (byteval << shift);
         }


### PR DESCRIPTION
### OS and Editor Version
- macOS Ventura 13.2
- ImHex Hex Editor v1.30.1

### Description
The console showed the error message `No variable named 'n' found.` when I opened an MP3 file with ID3 v2.4.0 tag and imported the ID3 pattern.

After tweaking the pattern, I found two ways to resolve the error:
- Remove the `ref` keyword from the argument `n` for the function `ssi_value`
- Use `size` as the variable name inside the function `ssi_value` (I changed the argument name to `size` too but it can be any name or even left empty)

I don't know which way is preferable. Maybe the problem is in the core library so the pattern file should not be changed at all. I have little knowledge about the behavior so I just opened the PR to see if it solves anything. Thanks for the good work and I enjoy the editor very much!

### Screenshot
#### The error
![id3_error](https://github.com/WerWolv/ImHex-Patterns/assets/20852502/4dc4f393-b19a-44c3-aad4-135dd64aa2df)
#### Remove `ref` keyword
![id3_error_solution_1](https://github.com/WerWolv/ImHex-Patterns/assets/20852502/ef7df501-4cb1-4ed6-b140-f200ff0b75d7)
#### Use `size` as the variable name
![id3_error_solution_2](https://github.com/WerWolv/ImHex-Patterns/assets/20852502/89941525-da85-4b48-811c-0bc95888323e)