### PR TITLE
patterns/flac: Fix SEEKTABLE metadata block

### DIFF
--- a/patterns/flac.hexpat
+++ b/patterns/flac.hexpat
@@ -307,6 +307,8 @@ struct METADATA_BLOCK {
 		METADATA_BLOCK_PADDING data;
 	else if (header.blockType == BLOCK_TYPE::APPLICATION)
 		METADATA_BLOCK_APPLICATION data;
+	else if (header.blockType == BLOCK_TYPE::SEEKTABLE)
+	     METADATA_BLOCK_SEEKTABLE data;
 	else if (header.blockType == BLOCK_TYPE::VORBIS_COMMENT)
 		METADATA_BLOCK_VORBIS_COMMENT data;
 	else if (header.blockType == BLOCK_TYPE::CUESHEET)


### PR DESCRIPTION
- Adds `METADATA_BLOCK_SEEKTABLE` to `METADATA_BLOCK`

Without `METADATA_BLOCK_SEEKTABLE` in this, the pattern errors 
![image](https://github.com/WerWolv/ImHex-Patterns/assets/97146561/43440686-7764-4ead-9baa-b2dc7d3006c4)

