### PR TITLE
fix payload size when ip header or tcp header has options in ip.hexpat

### DIFF
--- a/patterns/ip.hexpat
+++ b/patterns/ip.hexpat
@@ -132,7 +132,7 @@ namespace ip {
 			if (flags.data_offset > 5)
 				u8 options[(flags.data_offset - 5) * sizeof(u32)];
 				
-			u8 data[parent.parent.header.total_length - 40];
+			u8 data[parent.parent.header.total_length - parent.parent.header.ihl * 4 - flags.data_offset * 4];
 		};
 	
 	}


### PR DESCRIPTION
The orginal code was considering the IP header and TCP header has fixed lenght of 40 bytes. Actually it should be calculated by related header fileds in order to support any valid TCP packets.