### PR TITLE
patterns: fix description pragmas

### DIFF
--- a/patterns/intel_hex.hexpat
+++ b/patterns/intel_hex.hexpat
@@ -1,4 +1,4 @@
-#pragma description [Intel hexadecimal object file format definition]("https://en.wikipedia.org/wiki/Intel_HEX")
+#pragma description Intel hexadecimal object file format definition
 
 /* If you have no delimiters between data records then remove 
  * the null_bytes field in the data_packet struct.

--- a/patterns/uf2.hexpat
+++ b/patterns/uf2.hexpat
@@ -1,5 +1,5 @@
 #pragma author WerWolv
-#pragma description [USB Flashing Format](https://github.com/microsoft/uf2)
+#pragma description USB Flashing Format
 
 #include <std/sys.pat>
 #include <std/mem.pat>


### PR DESCRIPTION
Some description pragmas still had a markdown link syntax