### PR TITLE
MP4: Add childbox support for STBL boxes

### DIFF
--- a/patterns/mp4.hexpat
+++ b/patterns/mp4.hexpat
@@ -157,6 +157,18 @@ struct VideoMediaHeaderBox : FullBox {
     u16 opcolor[3];
 };
 
+struct SubSampleBoxTable {
+    u32 type = std::mem::read_unsigned($ + 4, 4, std::mem::Endian::Big);
+
+    match (str(type)) {
+        (_): UnknownBox box [[inline]];
+    }
+} [[name(std::format("SubSampleBoxTable({})", box.type))]];
+
+struct SampleBoxTable : BaseBox {
+    SubSampleBoxTable box[while($ < endOffset)] [[inline]];
+};
+
 struct SubMediaInformationBox {
     u32 type = std::mem::read_unsigned($ + 4, 4, std::mem::Endian::Big);
 
@@ -164,15 +176,12 @@ struct SubMediaInformationBox {
         ("vmhd"): VideoMediaHeaderBox box [[inline]];
         ("hdlr"): HandlerBox box [[inline]];
         ("dinf"): DataInformationBox box [[inline]];
+        ("stbl"): SampleBoxTable box [[inline]];
         (_): UnknownBox box [[inline]];
     }
 } [[name(std::format("MediaInformationBox({})", box.type))]];
 
 struct MediaInformationBox : BaseBox {
-    SubMediaInformationBox box[while($ < endOffset)] [[inline]];
-};
-
-struct SampleBoxTable : FullBox {
     SubMediaInformationBox box[while($ < endOffset)] [[inline]];
 };
 
@@ -199,7 +208,6 @@ struct SubMediaBox {
         ("mdhd"): MediaHeaderBox box [[inline]];
         ("hdlr"): HandlerBox box [[inline]];
         ("minf"): MediaInformationBox box [[inline]];
-        ("sbtl"): SampleBoxTable box [[inline]];
         (_): UnknownBox box [[inline]];
     }
 } [[name(std::format("MediaBox({})", box.type))]];

--- a/patterns/mp4.hexpat
+++ b/patterns/mp4.hexpat
@@ -157,10 +157,24 @@ struct VideoMediaHeaderBox : FullBox {
     u16 opcolor[3];
 };
 
+struct SubSampleDescriptionBox {
+    u32 type = std::mem::read_unsigned($ + 4, 4, std::mem::Endian::Big);
+
+    match (str(type)) {
+        (_): UnknownBox box [[inline]];
+    }
+} [[name(std::format("SubSampleDescriptionBox({})", box.type))]];
+
+struct SampleDescriptionBox : FullBox {
+        u32 entry_count;
+        SubSampleDescriptionBox box[while($ < endOffset)] [[inline]];
+};
+
 struct SubSampleBoxTable {
     u32 type = std::mem::read_unsigned($ + 4, 4, std::mem::Endian::Big);
 
     match (str(type)) {
+        ("stsd"): SampleDescriptionBox box [[inline]];
         (_): UnknownBox box [[inline]];
     }
 } [[name(std::format("SubSampleBoxTable({})", box.type))]];


### PR DESCRIPTION
Previously the mp4 pattern could only see the existence of STBL boxes, with this PR it can also see child boxes inside

It also adds  support for the SampleDescriptionBox(STSD), which contain information about which codec is used. "mp4a" and "avc1" in this examples below

[mp4a](https://en.wikipedia.org/?title=Mp4a&redirect=no):
![Screenshot from 2023-11-13 19-24-39](https://github.com/WerWolv/ImHex-Patterns/assets/78051485/549b71ef-acd3-4664-9b81-552594bba24c)

[avc1](https://en.wikipedia.org/wiki/Advanced_Video_Coding):
![Screenshot from 2023-11-13 19-41-52](https://github.com/WerWolv/ImHex-Patterns/assets/78051485/715e8988-0ef3-413e-ae2f-b9265fc7df5a)
