### PR TITLE
MP4: make handler_type into a char[4], which reflects how it is used

### DIFF
--- a/patterns/mp4.hexpat
+++ b/patterns/mp4.hexpat
@@ -147,7 +147,7 @@ struct DataInformationBox : BaseBox {
 
 struct HandlerBox : FullBox {
     u32 component_type;
-    u32 handler_type;
+    char handler_type[4];
     u32 reserved[3];
     char name[endOffset - $];
 };


### PR DESCRIPTION
handler_type is actually a 4 character string, so it better be represented as a char[4] (instead of u32)
example values are "soun" and "vide", here is a list of possible values

https://cconcolato.github.io/mp4ra/handler.html

Screenshot of handler_type="soun" (when changed to char[4])
![Screenshot from 2023-11-13 17-45-03](https://github.com/WerWolv/ImHex-Patterns/assets/78051485/58137d0b-090b-4076-bac3-fe5ca270f6cb)
