### PR TITLE
fix:  [ImHex Bug] std::string::replace("aa", "aa", "") returns "a" #1408

### DIFF
--- a/includes/std/string.pat
+++ b/includes/std/string.pat
@@ -209,31 +209,27 @@ namespace std::string {
 		@param replace The substring to replace with.
 		@return The string with the replacements.
 	*/
-    fn replace(str string, str pattern, str replace) {
-    	u32 string_len, pattern_len, replace_len;
-		string_len  = std::string::length(string);
-		pattern_len = std::string::length(pattern);
-		replace_len = std::string::length(replace);
-		
-		if (pattern_len > string_len)
-			return string;
-			
+	fn replace(str string, str pattern, str replace) {
+		s32 string_len  = std::string::length(string);
+		s32 pattern_len = std::string::length(pattern);
+
+		if (pattern_len > string_len || pattern_len * string_len == 0 )
+ 			return string;
+
 		str result;
-		u32 i;
-		while (i <= (string_len - pattern_len)) {
-			
-			if (std::string::substr(string, i, pattern_len) == pattern) {
-				result = result + replace;
-				i = i + pattern_len;
-			} else {
-				result = result + std::string::at(string, i);
-				i = i + 1;
+		s32 string_index;
+		s32 remaining_len = string_len;
+		while ( pattern_len <= remaining_len ) {
+			if ( std::string::substr(string, string_index, pattern_len) == pattern ) {
+ 				result += replace;
+				string_index += pattern_len;
+ 			} else {
+				result += std::string::at(string, string_index);
+  				string_index += 1;
 			}
+			remaining_len = string_len - string_index;
 		}
-		result = result + std::string::substr(string,string_len-pattern_len+1,pattern_len);
-		
+		result += std::string::substr(string, string_index, remaining_len );
 		return result;
 	};
-
-
 }

--- a/includes/std/string.pat
+++ b/includes/std/string.pat
@@ -219,8 +219,8 @@ namespace std::string {
 		str result;
 		s32 string_index;
 		s32 remaining_len = string_len;
-		while ( pattern_len <= remaining_len ) {
-			if ( std::string::substr(string, string_index, pattern_len) == pattern ) {
+		while (pattern_len <= remaining_len) {
+			if (std::string::substr(string, string_index, pattern_len) == pattern) {
  				result += replace;
 				string_index += pattern_len;
  			} else {


### PR DESCRIPTION
The previous fixes for this function didn't consider the case when the resulting string has a contribution from the original string that occurs after all the substitutions have been made and that is longer than the replacement string. This PR resolves that issue and also addresses the case where one or more of the inputs is empty. Please see discussion on [ImHex issue #1408](https://github.com/WerWolv/ImHex/issues/1408) for details.