### PR TITLE
add pe mime for arch linux

### DIFF
--- a/patterns/pe.hexpat
+++ b/patterns/pe.hexpat
@@ -3,6 +3,7 @@
 
 #pragma MIME application/x-dosexec
 #pragma MIME application/x-msdownload
+#pragma MIME application/vnd.microsoft.portable-executable
 
 #include <std/core.pat>
 #include <std/string.pat>


### PR DESCRIPTION
on arch linux, libmagick detects pe files mime as "application/vnd.microsoft.portable-executable"