### PR TITLE
Replace get_attribute_value with get_attribute_argument

### DIFF
--- a/includes/std/core.pat
+++ b/includes/std/core.pat
@@ -38,12 +38,20 @@ namespace auto std::core {
     };
 
     /**
-        Returns the first parameter of the attribute of a pattern if it has one
+        Returns the nth parameter of the attribute of a pattern if it has one
         @param pattern The pattern to check
         @param attribute The attribute's name to query
+        @param [index] The parameter index of the attribute to return. Defaults to 0
+    */
+    fn get_attribute_argument(ref auto pattern, str attribute, u32 index = 0) {
+        return builtin::std::core::get_attribute_argument(pattern, attribute, index);
+    };
+
+    /**
+        @warning Removed in 1.27.0
     */
     fn get_attribute_value(ref auto pattern, str attribute) {
-        return builtin::std::core::get_attribute_value(pattern, attribute);
+        builtin::std::error("`std::core::get_attribute_value(pattern, attribute)` has been removed.\nUse `std::core::get_attribute_argument(pattern, attribute, [index])` instead.");
     };
 
 

--- a/includes/std/math.pat
+++ b/includes/std/math.pat
@@ -328,9 +328,9 @@ namespace auto std::math {
 		@param start Start address
 		@param end End address
 		@param valueSize Size of each value in bytes
-		@param section Section to use
-		@param operation Operation to use
-		@param endian Endianness to use
+		@param [section] Section to use
+		@param [operation] Operation to use. Defaults to addition
+		@param [endian] Endianness to use. Defaults to native
 		@return Sum of all values in the specified memory range
 	*/
 	fn accumulate(u128 start, u128 end, u128 valueSize, std::mem::Section section = 0, AccumulateOperation operation = AccumulateOperation::Add, std::mem::Endian endian = std::mem::Endian::Native) {

--- a/includes/std/mem.pat
+++ b/includes/std/mem.pat
@@ -104,7 +104,7 @@ namespace auto std::mem {
         Reads a unsigned value from the memory
         @param address The address to read from
         @param size The size of the value to read
-        @param endian The endianess of the value to read
+        @param [endian] The endianess of the value to read. Defaults to native
         @return The value read
     */
     fn read_unsigned(u128 address, u8 size, Endian endian = Endian::Native) {
@@ -115,7 +115,7 @@ namespace auto std::mem {
         Reads a signed value from the memory
         @param address The address to read from
         @param size The size of the value to read
-        @param endian The endianess of the value to read
+        @param [endian] The endianess of the value to read. Defaults to native
         @return The value read
     */
     fn read_signed(u128 address, u8 size, Endian endian = Endian::Native) {

--- a/includes/std/random.pat
+++ b/includes/std/random.pat
@@ -61,8 +61,8 @@ namespace auto std::random {
         > - `Poisson(mean) -> i128`
 
         @param distribution Distribution to use
-        @param param1 This parameter depends on the type of distribution used.
-        @param param2 This parameter depends on the type of distribution used.
+        @param [param1] This parameter depends on the type of distribution used. Defaults to 0
+        @param [param2] This parameter depends on the type of distribution used. Defaults to 0
     */
     fn generate_using(Distribution distribution, auto param1 = 0, auto param2 = 0) {
         return builtin::std::random::generate(u32(distribution), param1, param2);
@@ -71,8 +71,8 @@ namespace auto std::random {
     
     /**
         Generates a uniformly distributed random number between `min` and `max`
-        @param min Minimum number
-        @param max Maximum number
+        @param [min] Minimum number. Defaults to 0
+        @param [max] Maximum number. Defaults to `u64_max`
     */
     fn generate(u64 min = std::limits::u64_min(), u64 max = std::limits::u64_max()) {
         return std::random::generate_using(Distribution::Uniform, min, max);

--- a/includes/std/time.pat
+++ b/includes/std/time.pat
@@ -113,7 +113,7 @@ namespace auto std::time {
 
 	/**
 		Queries the current time in the specified time zone.
-		@param time_zone The time zone to query.
+		@param [time_zone] The time zone to query. Defaults to local.
 		@return The current time in the specified time zone.
 	*/
 	fn now(TimeZone time_zone = TimeZone::Local) {
@@ -167,7 +167,7 @@ namespace auto std::time {
 	/**
 		Formats a time according to the specified format string.
 		@param time The time to format.
-		@param format_string The format string to use.
+		@param [format_string] The format string to use. Defaults to "%c".
 		@return The formatted time.
 	*/
 	fn format(Time time, str format_string = "%c") {
@@ -180,7 +180,7 @@ namespace auto std::time {
 	/**
 		Formats a DOS date according to the specified format string.
 		@param date The DOS date to format.
-		@param format_string The format string to use.
+		@param [format_string] The format string to use. Defaults to "{}/{}/{}".
 		@return The formatted DOS date.
 	*/
 	fn format_dos_date(DOSDate date, str format_string = "{}/{}/{}") {
@@ -190,7 +190,7 @@ namespace auto std::time {
 	/**
 		Formats a DOS time according to the specified format string.
 		@param time The DOS time to format.
-		@param format_string The format string to use.
+		@param [format_string] The format string to use. Defaults to "{:02}:{:02}:{:02}".
 		@return The formatted DOS time.
 	*/
 	fn format_dos_time(DOSTime time, str format_string = "{:02}:{:02}:{:02}") {


### PR DESCRIPTION
In early 2023, `builtin::std::core::get_attribute_value(pattern, attribute)` was changed to `builtin::std::core::get_attribute_argument(pattern, attribute, index)`, and a third parameter was added to that function.
"*includes/std/core.pat*" was never updated for either of those things, causing compile errors when using `std::core::get_attribute_value` in a pattern.

This pull request updates that file to add `std::core::get_attribute_argument(pattern, attribute, [index])` (with `index` defaulting to 0), and makes `std::core::get_attribute_value` show you an error telling you to use `std::core::get_attribute_argument` instead. (I would've made `std::core::get_attribute_value` use an index of 0, but given that it's been broken for over a year, I don't think that a lot of current patterns use it.)

(This pull request also updates the library documentation comments to have square brackets around optional arguments and list their default values, to correspond with https://github.com/WerWolv/Documentation/pull/12.)

\
Note that this is untested; ImHex tells me `runtime error: Cannot cast value to type 'pattern'` while evaluating a pattern where I try to use pattern-related functions. Therefore, I don't know whether `index` should default to 0 or to 1, so I just assumed 0.