### PR TITLE
Add 7z MIME

### DIFF
--- a/patterns/7z.hexpat
+++ b/patterns/7z.hexpat
@@ -1,4 +1,5 @@
 #pragma description 7z File Format
+#pragma MIME application/x-7z-compressed
 
 import std.io; 
 import std.mem; 


### PR DESCRIPTION
without this imhex don't detect .7z files (archlinux flatpak)