### PR TITLE
Correctly call builtin flush

### DIFF
--- a/includes/std/file.pat
+++ b/includes/std/file.pat
@@ -97,7 +97,7 @@ namespace auto std::file {
 		@param handle The handle of the file to flush
 	*/
 	fn flush(Handle handle) {
-		builtin::std::file::remove(handle);
+		builtin::std::file::flush(handle);
 	};
 
 


### PR DESCRIPTION
The std::file::flush function called the builtin remove function instead of the builtin flush function, meaning that any call to flush would actually delete the file