### PR TITLE
Add add_virtual_file to hex/core.pat

### DIFF
--- a/includes/hex/core.pat
+++ b/includes/hex/core.pat
@@ -37,4 +37,14 @@ namespace auto hex::core {
         return result;
     };
 
+    /**
+        Add a file to the Virtual Filesystem
+        @param path The name of the file
+        @param pattern The pattern associated with the file
+    */
+    fn add_virtual_file(str path, auto pattern)
+    {
+        builtin::hex::core::add_virtual_file(path, pattern);
+    }
+
 }


### PR DESCRIPTION
This function is implemented [here](https://github.com/WerWolv/ImHex/blob/master/plugins/builtin/source/content/pl_builtin_functions.cpp#L32-L45), yet is never directly exposed using the hex/core.pat pattern file.