### PR TITLE
Add some fixes from the WerWolv/Documentation repo

### DIFF
--- a/includes/std/sys.pat
+++ b/includes/std/sys.pat
@@ -10,7 +10,7 @@ namespace auto std {
 
     /**
         Asserts that a given value is true. If it's not, abort evaluation and print the given message to the console
-        @param conditoon The condition that is required to be true
+        @param condition The condition that is required to be true
         @param message The message to print in case the assertion doesn't hold
     */
     fn assert(bool condition, str message) {
@@ -21,7 +21,7 @@ namespace auto std {
 
     /**
         Asserts that a given value is true. If it's not, print the given message to the console as a warning
-        @param conditoon The condition that is required to be true
+        @param condition The condition that is required to be true
         @param message The message to print in case the assertion doesn't hold
     */
     fn assert_warn(bool condition, str message) {

--- a/includes/type/path.pat
+++ b/includes/type/path.pat
@@ -34,7 +34,7 @@ namespace auto type {
 	using UnixPath = Path<"/">;
 
 	/**
-		A type representing a DOS path using a '\' backslash as delimeter
+		A type representing a DOS path using a '\\' backslash as delimeter
 	*/
 	using DOSPath = Path<"\\">;
 	


### PR DESCRIPTION
1. Escape backslash in DOSPath docs. Thanks to @vlenhart for noticing the error here: https://github.com/WerWolv/Documentation/pull/9
2. Spelling correction for std\sys.pat. Thanks to @bluestonethe2nd for submitting a PR here: https://github.com/WerWolv/Documentation/pull/14