### PR TITLE
Update core.pat - fix set_pattern_comment

### DIFF
--- a/includes/std/core.pat
+++ b/includes/std/core.pat
@@ -159,10 +159,10 @@ namespace auto std::core {
     /**
         Changes the comment attached to a pattern
         @param pattern The pattern to modify
-        @param name The new comment of the pattern
+        @param comment The new comment of the pattern
     */
     fn set_pattern_comment(ref auto pattern, str comment) {
-        builtin::std::core::set_pattern_comment(pattern, name);
+        builtin::std::core::set_pattern_comment(pattern, comment);
     }; 
 
     /**


### PR DESCRIPTION
Probably a copy-paste issue - std::core::set_pattern_comment has a parameter `comment`, but was using (and the comment was documenting) `name`