### PR TITLE
Fix msgpack bugs

### DIFF
--- a/patterns/msgpack.hexpat
+++ b/patterns/msgpack.hexpat
@@ -142,16 +142,14 @@ struct MessagePack {
 		s8 type;
 		u8 data[length];
 	} else if (type == Type::Ext16) {
-		u16 length;
+		be u16 length;
 		s8 type;
 		u8 data[length];
 	} else if (type == Type::Ext32) {
-		u32 length;
+		be u32 length;
 		s8 type;
 		u8 data[length];
 	}
-		
-		
 };
 
 MessagePack pack @ 0x00;

--- a/patterns/msgpack.hexpat
+++ b/patterns/msgpack.hexpat
@@ -43,14 +43,6 @@ enum Type : u8 {
 	NegativeFixInt		= 0xE0 ... 0xFF
 };
 
-fn format_positive_fixint(u8 value) {
-	return value & 0b0111'1111;
-};
-
-fn format_negative_fixint(u8 value) {
-	return -(value & 0b0001'1111);
-};
-
 using MessagePack;
 
 struct MapEntry {
@@ -62,10 +54,10 @@ struct MessagePack {
 	
 	if (u8(type) <= 0x7F) {
 		$ -= 1;
-		u8 value [[format("format_positive_fixint")]];
+		u8 value;
 	} else if (u8(type) >= Type::NegativeFixInt) {
 		$ -= 1;
-		u8 value [[format("format_negative_fixint")]];
+		s8 value;
 	} else if (type == Type::Uint8)
 		be u8 value;
 	else if (type == Type::Uint16)


### PR DESCRIPTION
* 16-bit and 32-bit extension lengths were not marked big-endian.
* Negative fixint values were being mangled.