### PR TITLE
Adding checks to ends_with and starts_with to prevent failure

### DIFF
--- a/includes/std/string.pat
+++ b/includes/std/string.pat
@@ -125,6 +125,8 @@ namespace auto std::string {
         @return True if the string starts with the substring, false otherwise.
     */
     fn starts_with(str string, str part) {
+        if (std::string::length(string) < std::string::length(part))
+            return false;
         return std::string::substr(string, 0, std::string::length(part)) == part;
     };
 
@@ -135,6 +137,8 @@ namespace auto std::string {
         @return True if the string ends with the substring, false otherwise.
     */
     fn ends_with(str string, str part) {
+        if (std::string::length(string) < std::string::length(part))
+            return false;
         return std::string::substr(string, std::string::length(string) - std::string::length(part), std::string::length(part)) == part;
     };
 


### PR DESCRIPTION
Fixing cases where part is longer than string, this cases should both return false instead of failing.

E.g.:
```rust
ends_with("asdf", "0123456789");
```
fails with
```
E: runtime error: Character index 4294967290 out of range of string 'asdf' with length 4.
```
but it should simply return `false`.

This should be merged together with a fix to the builtin substr function to throw an error if the desired substring does not fit inside the string.