### PR TITLE
Fixed a bug in the Lua 5.1 bytecode pattern

### DIFF
--- a/patterns/lua51.hexpat
+++ b/patterns/lua51.hexpat
@@ -72,7 +72,7 @@ struct LocalVar {
 struct LuaDebugInfo {
     Vector<u32> lineInfo;
     Vector<LocalVar> localVar;
-    Vector<u32> upvalues;
+    Vector<LuaString> upvalues;
 };
 
 struct LuaConstants{


### PR DESCRIPTION
Lua 5.1 bytecode upvalue fields were incorrectly defined as a `Vector<u32>` instead of `Vector<LuaString>`.