### PR TITLE
patterns/gb: Add 16K and 32K arrays for ROM Banks

### DIFF
--- a/patterns/gb.hexpat
+++ b/patterns/gb.hexpat
@@ -7,6 +7,9 @@ import type.size;
 import std.string;
 import std.mem;
 
+const u16 ROMBANKSIZE_16K = 0x4000;
+const u16 ROMBANKSIZE_32K = 0x8000;
+
 bool uppercaseROMFeatures in;
 bool brandedROMFeatures in;
 
@@ -356,6 +359,16 @@ struct JumpVectors {
 	u8 int4[8] [[comment("serial")]];
 	u8 int5[8] [[comment("joypad")]];
 };
+
+struct romBank16K {
+    u8 Bank[ROMBANKSIZE_16K];
+};
+struct romBank32K {
+    u8 Bank[ROMBANKSIZE_32K];
+};
+
+romBank16K romBanks16K[std::mem::size() / ROMBANKSIZE_16K] @ 0x00;
+romBank32K romBanks32K[std::mem::size() / ROMBANKSIZE_32K] @ 0x00;
 
 JumpVectors jumpVectors @ 0x00 [[comment("Instructions called on interrupts or RST instructions")]];
 CartridgeStart cartridgeStart @ 0x100;


### PR DESCRIPTION
Having arrays for dividing the GB ROM up into ROM Banks makes it much easier to jump to and inspect data at the start and end of banks.

- 16K Banks are the typical standard
- 32K banks aren't very common but are used in a couple unlicensed Games such as those using the Wisdom Tree MBC controller

![imhex_gb-rombanks](https://github.com/user-attachments/assets/24a14757-35a1-449e-82bd-3ff2ad1909c0)