### PR TITLE
Add parsing of general purpose bit flag in ZIP pattern

### DIFF
--- a/patterns/zip.hexpat
+++ b/patterns/zip.hexpat
@@ -157,17 +157,17 @@ enum CompressionMethod : u16 {
 };
 
 bitfield GeneralPurposeBitFlags {
-    bool encrypted : 1;
-    bool compressionOptions : 2;
-    bool crcAndSizesInCDAndDataDescriptor : 1;
-    bool enhancedDefalting : 1;
-    bool patchedData : 1;
-    bool strongEncryption : 1;
-    bool unused : 4;
-    bool filenameAndCommentAreUtf8 : 1;
-    bool reservedPKWARE_0 : 1;
-    bool centralDirectoryEncrypted : 1;
-    bool reservedPKWARE_1 : 2;
+    encrypted : 1;
+    compressionOptions : 2;
+    crcAndSizesInCDAndDataDescriptor : 1;
+    enhancedDeflating : 1;
+    patchedData : 1;
+    strongEncryption : 1;
+    unused : 4;
+    filenameAndCommentAreUtf8 : 1;
+    reservedPKWARE_0 : 1;
+    centralDirectoryEncrypted : 1;
+    reservedPKWARE_1 : 2;
 };
 
 struct LocalFileHeader {

--- a/patterns/zip.hexpat
+++ b/patterns/zip.hexpat
@@ -156,10 +156,24 @@ enum CompressionMethod : u16 {
   AE_x = 99,             // AE-x encryption marker (see APPENDIX E)
 };
 
+bitfield GeneralPurposeBitFlags {
+    bool encrypted : 1;
+    bool compressionOptions : 2;
+    bool crcAndSizesInCDAndDataDescriptor : 1;
+    bool enhancedDefalting : 1;
+    bool patchedData : 1;
+    bool strongEncryption : 1;
+    bool unused : 4;
+    bool filenameAndCommentAreUtf8 : 1;
+    bool reservedPKWARE_0 : 1;
+    bool centralDirectoryEncrypted : 1;
+    bool reservedPKWARE_1 : 2;
+};
+
 struct LocalFileHeader {
     u32 headerSignature [[name("LCF PK\\3\\4")]];
     u16 version [[ comment("The minimum supported ZIP specification version needed to extract the file") ]];
-    u16 purposeBitflag  [[ comment("General purpose bit flag") ]];
+    GeneralPurposeBitFlags generalPurposeBitFlags  [[ comment("General purpose bit flag") ]];
     CompressionMethod compressionMethod [[ comment("Compression method") ]];
     u16 lastModifyTime [[ comment("File last modification time") ]];
     u16 lastModifyDate [[ comment("File last modification date") ]];
@@ -183,7 +197,7 @@ struct CentralDirectoryFileHeader {
     u32 headerSignature [[name("CDFH PK\\1\\2")]];
     u16 versionMade [[comment("Version file made by")]];
     u16 versionExtract [[comment("Minimum version needed to extract")]];
-    u16 generalFlag [[comment("General purpose bit flag")]];
+    GeneralPurposeBitFlags generalPurposeBitFlags [[comment("General purpose bit flag")]];
     CompressionMethod compressionMethod;
     u16 fileLastModifyTime [[comment("File last modification time")]];
     u16 fileLastModifyDate [[comment("File last modification date")]];


### PR DESCRIPTION
Add "GeneralPurposeBitFlags" bitfield definition to the ZIP pattern. The names are based on the official ZIP format specification, although I chose to name the fields closer to their purpose rather than their official name. This is intended to make reading the pattern and its output easier. Example: official name "Language encoding flag (EFS)" my name "filenameAndCommentAreUtf8" because this immediately explains what it does.

I chose not to implement the specifics of the "compressionOptions" as their meanings are specific to the compression method used, and it would make the pattern much more complicated for (in my opinion) little gain.

I also chose to unify the names of the general purpose bit filed in the LocalFileHeader and the CentralDirectoryFileHeader. Previously, they had different names, suggesting they might have different meaning. According to the official docs though, these fields have the exact same meaning.

Official docs: https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT