### PR TITLE
Fix pe not working when ordinalTableRVA is zero

### DIFF
--- a/patterns/pe.hexpat
+++ b/patterns/pe.hexpat
@@ -393,7 +393,9 @@ struct ExportsTable {
 	ExportDirectoryTable directoryTable;
 	ExportAddress exportAddressTable[directoryTable.addressesAmount] @ directoryTable.addressTableRVA - relativeVirtualDifference();
 	ExportNamePointer exportNamePointerTable[directoryTable.namePointersAmount] @ directoryTable.namePointerTableRVA - relativeVirtualDifference();
-	u16 exportOrdinalTable[directoryTable.namePointersAmount] @ directoryTable.ordinalTableRVA - relativeVirtualDifference();
+	if (directoryTable.ordinalTableRVA > relativeVirtualDifference()) {
+		u16 exportOrdinalTable[directoryTable.namePointersAmount] @ directoryTable.ordinalTableRVA - relativeVirtualDifference();
+	}
 	char imageName[] @ directoryTable.imageNameRVA - relativeVirtualDifference() [[format("formatNullTerminatedString")]];
 	$ = addressof(this)+coffHeader.optionalHeader.directories[0].size;
 };


### PR DESCRIPTION
Export table might not exist in pe exe. if  ordinalTableRVA is zero. pattern will failed to parse