### PR TITLE
Add 'stsz' box definition to MP4 pattern

### DIFF
--- a/patterns/mp4.hexpat
+++ b/patterns/mp4.hexpat
@@ -283,6 +283,14 @@ struct CompositionOffsetBox: FullBox {
     }
 };
 
+struct SampleSizeBox: FullBox {
+    u32 sample_size;
+    u32 sample_count;
+    if(this.sample_size==0) {
+        u32 entry_size[this.sample_count];
+    }
+};
+
 struct SubSampleBoxTable {
     u32 type = std::mem::read_unsigned($ + 4, 4, std::mem::Endian::Big);
 
@@ -293,6 +301,7 @@ struct SubSampleBoxTable {
         ("stco"): ChunkOffsetBox box [[inline]];
         ("stss"): SyncSampleBox box [[inline]];
         ("ctts"): CompositionOffsetBox box [[inline]];
+        ("stsz"): SampleSizeBox box [[inline]];
         (_): UnknownBox box [[inline]];
     }
 } [[name(std::format("SubSampleBoxTable({})", box.type))]];


### PR DESCRIPTION
Definition of `stsz` box.

**ISO base media file format**

8.7.3.2 Sample Size Box
8.7.3.2.1 Syntax
```
aligned(8) class SampleSizeBox extends FullBox(‘stsz’, version = 0, 0) {
unsigned int(32) sample_size;
unsigned int(32) sample_count; if (sample_size==0) { for (i=1; i <= sample_count; i++) {
unsigned int(32) entry_size; }
} }
```