### PR TITLE
Misc style cleanup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pattern_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pattern_template.md
@@ -9,4 +9,4 @@
 - [ ] The pattern was associated with all relevant MIME types (using `#pragma MIME mime-type` in the source code)
   - Make sure to never use `application/octet-stream` here as that means "Unidentifiable binary data"
 - [ ] A test file for this pattern has been added to [/tests/patterns/test_data](/tests/patterns/test_data)
-  - Try to keep this file below ~ 1 MB 
+  - Try to keep this file below ~ 1 MB

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
     - name: 🧰 Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: 📄 Check changed include files
       id: changed-includes
-      uses: tj-actions/changed-files@v35
+      uses: tj-actions/changed-files@v45
       with:
         files: includes/**/*.pat
 

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -8,7 +8,7 @@ on:
   repository_dispatch:
     types: [run_tests]
   workflow_dispatch:
-    inputs: 
+    inputs:
       generate_docs:
         description: "Regenerate docs"
         required: false
@@ -45,7 +45,7 @@ jobs:
         repo: Documentation
         owner: WerWolv
         event_type: update_pl_docs
-        
+
     - name: ✉️ Update PatternLanguage Website
       if: ${{ env.DISPATCH_TOKEN != '' }}
       uses: mvasigh/dispatch-action@main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: 🧰 Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
             python3-pip           \
             libmagic-dev          \
             lcov
-        
+
         sudo pip install jsonschema
 
     - name: 📜 Setup ccache
@@ -74,7 +74,7 @@ jobs:
         cd constants
         for file in ./[!_schema.json]*; do jsonschema -i $file _schema.json; done
         cd ..
-        
+
         cd tips
         for file in ./[!_schema.json]*; do jsonschema -i $file _schema.json; done
         cd ..

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,5 +8,5 @@ Thanks a lot for any additions or improvements :)
 ## Adding new Patterns
 
 When adding new patterns, if possible, please also add a test file named `<pattern_name>.hexpat.<extension>` to the `/tests/patterns/test_data` directory. This allows our Unit Tests to be run against your code so we can make sure it stays up-to-date and doesn't break when changes are made to the PatternLanguage.
-Please try to keep these files as small as possible (~100kiB at most) so cloning stays fast. 
+Please try to keep these files as small as possible (~100kiB at most) so cloning stays fast.
 Please also make sure to not submit any test files that are under copyright such as game files, ROMs or files extracted from other programs. We don't want a DMCA takedown on this repo.

--- a/constants/linux_errors.json
+++ b/constants/linux_errors.json
@@ -775,6 +775,6 @@
             "name": "ENOTRECOVERABLE",
             "desc": "State not recoverable"
         }
-        
+
     ]
 }

--- a/includes/hex/provider.pat
+++ b/includes/hex/provider.pat
@@ -7,11 +7,11 @@ import hex.impl.imhex_check;
 */
 
 namespace auto hex::prv {
-    
-    
+
+
     /**
         Queries information from the currently loaded provider. The kind of information that's available depends on the provider that's loaded
-        
+
         > **Available information**
         > - File Provider
         >   - `file_path() -> str`
@@ -32,12 +32,12 @@ namespace auto hex::prv {
         >   - `region_size(regionName) -> u64`
         >   - `process_id() -> u32`
         >   - `process_name() -> str`
-        
+
         @param category Information category
         @param argument Extra argument to pass along
     */
     fn get_information(str category, str argument = "") {
         return builtin::hex::prv::get_information(category, argument);
     };
-    
+
 }

--- a/includes/std/bit.pat
+++ b/includes/std/bit.pat
@@ -21,7 +21,7 @@ namespace auto std::bit {
         x = (x & a) + ((x >> 1) & a);
         x = (x & b) + ((x >> 2) & b);
         x = (x & c) + ((x >> 4) & c);
-        
+
         return x % 0xFF;
     };
 
@@ -33,19 +33,19 @@ namespace auto std::bit {
     fn has_single_bit(u128 x) {
         return x != 0 && (x & (x - 1)) == 0;
     };
-    
+
     /**
         Rounds the given number up to the next bigger power of two
         @param x The number
         @return Next bigger power of two that can fit `x`
     */
-    fn bit_ceil(u128 x) {        
+    fn bit_ceil(u128 x) {
         if (x == 0) return 0;
-        
+
         u8 i;
         while ((1 << i) < x)
             i = i + 1;
-        
+
         return 1 << i;
     };
 
@@ -56,11 +56,11 @@ namespace auto std::bit {
     */
     fn bit_floor(u128 x) {
         if (x == 0) return 0;
-        
+
         u8 i;
         while ((x >> i) > 0)
             i = i + 1;
-        
+
         return 1 << (i - 1);
     };
 

--- a/includes/std/file.pat
+++ b/includes/std/file.pat
@@ -1,7 +1,7 @@
 #pragma once
 
 /*!
-    The File library allows reading and writing from/to external files using 
+    The File library allows reading and writing from/to external files using
     a C-like File IO API.
 
     **These functions are considered dangerous and require the user to manually permit them**
@@ -13,7 +13,7 @@ namespace auto std::file {
         A handle representing a file that has been opened
     */
     using Handle = s32;
-    
+
     /**
         The mode to open a file in.
         Read opens the file in read-only mode
@@ -45,7 +45,7 @@ namespace auto std::file {
         builtin::std::file::close(handle);
     };
 
-    
+
     /**
         Reads the content of a file into a string
         @param handle The file handle to read from
@@ -85,14 +85,14 @@ namespace auto std::file {
     };
 
     /**
-        Resizes a file 
+        Resizes a file
         @param handle The handle of the file to resize
     */
     fn resize(Handle handle, u64 size) {
         builtin::std::file::resize(handle, size);
     };
 
-    /** 
+    /**
         Flushes changes made to a file to disk
         @param handle The handle of the file to flush
     */

--- a/includes/std/fxpt.pat
+++ b/includes/std/fxpt.pat
@@ -20,7 +20,7 @@ namespace auto std::fxpt {
     fn to_float(fixed fxt, u32 precision) {
         return double(fxt) / double((1 << precision));
     };
-    
+
     /**
         Converts a floating point value into a fixed point value
         @param flt The floating point value to convert
@@ -41,7 +41,7 @@ namespace auto std::fxpt {
     fn change_precision(fixed value, u32 start_precision, u32 end_precision) {
         return std::fxpt::to_fixed(std::fxpt::to_float(value, start_precision), end_precision);
     };
-    
+
     /**
         Adds two fixed point numbers with a given precision together
         @param a First fixed point number
@@ -52,7 +52,7 @@ namespace auto std::fxpt {
     fn add(fixed a, fixed b, u32 precision) {
         return a + b;
     };
-    
+
     /**
         Subtracts two fixed point numbers with a given precision together
         @param a First fixed point number
@@ -63,7 +63,7 @@ namespace auto std::fxpt {
     fn subtract(fixed a, fixed b, u32 precision) {
         return a - b;
     };
-    
+
     /**
         Multiplies two fixed point numbers with a given precision together
         @param a First fixed point number
@@ -74,7 +74,7 @@ namespace auto std::fxpt {
     fn multiply(fixed a, fixed b, u32 precision) {
         return (a * b) / (1 << precision);
     };
-    
+
     /**
         Divides two fixed point numbers with a given precision together
         @param a First fixed point number

--- a/includes/std/hash.pat
+++ b/includes/std/hash.pat
@@ -14,7 +14,7 @@ namespace auto std::hash {
         @param xorout The CRC8 XOR-Out value
         @param reflect_in Whether or not the input bytes should be reflected
         @param reflect_out Whether or not the output should be reflected
-        @return Calculated CRC8 hash 
+        @return Calculated CRC8 hash
     */
     fn crc8(ref auto pattern, u8 init, u8 poly, u8 xorout, bool reflect_in, bool reflect_out) {
         return builtin::std::hash::crc8(pattern, init, poly, xorout, reflect_in, reflect_out);
@@ -28,7 +28,7 @@ namespace auto std::hash {
         @param xorout The CRC16 XOR-Out value
         @param reflect_in Whether or not the input bytes should be reflected
         @param reflect_out Whether or not the output should be reflected
-        @return Calculated CRC16 hash 
+        @return Calculated CRC16 hash
     */
     fn crc16(ref auto pattern, u16 init, u16 poly, u16 xorout, bool reflect_in, bool reflect_out) {
         return builtin::std::hash::crc16(pattern, init, poly, xorout, reflect_in, reflect_out);
@@ -42,7 +42,7 @@ namespace auto std::hash {
         @param xorout The CRC32 XOR-Out value
         @param reflect_in Whether or not the input bytes should be reflected
         @param reflect_out Whether or not the output should be reflected
-        @return Calculated CRC32 hash 
+        @return Calculated CRC32 hash
     */
     fn crc32(ref auto pattern, u32 init, u32 poly, u32 xorout, bool reflect_in, bool reflect_out) {
         return builtin::std::hash::crc32(pattern, init, poly, xorout, reflect_in, reflect_out);
@@ -56,7 +56,7 @@ namespace auto std::hash {
         @param xorout The CRC64 XOR-Out value
         @param reflect_in Whether or not the input bytes should be reflected
         @param reflect_out Whether or not the output should be reflected
-        @return Calculated CRC64 hash 
+        @return Calculated CRC64 hash
     */
     fn crc64(ref auto pattern, u64 init, u64 poly, u64 xorout, bool reflect_in, bool reflect_out) {
         return builtin::std::hash::crc64(pattern, init, poly, xorout, reflect_in, reflect_out);

--- a/includes/std/limits.pat
+++ b/includes/std/limits.pat
@@ -5,7 +5,7 @@
 */
 
 namespace auto std::limits {
-    
+
     /**
         Returns the minimum value that can be stored in a `u8`.
         @return Minimum value
@@ -13,7 +13,7 @@ namespace auto std::limits {
     fn u8_min() {
         return u8(0);
     };
-    
+
     /**
         Returns the maximum value that can be stored in a `u8`.
         @return Maximum value
@@ -29,7 +29,7 @@ namespace auto std::limits {
     fn s8_min() {
         return -s8((std::limits::u8_max() / 2)) - 1;
     };
-    
+
     /**
         Returns the maximum value that can be stored in a `s8`.
         @return Maximum value
@@ -45,7 +45,7 @@ namespace auto std::limits {
     fn u16_min() {
         return u16(0);
     };
-    
+
     /**
         Returns the maximum value that can be stored in a `u16`.
         @return Maximum value
@@ -53,7 +53,7 @@ namespace auto std::limits {
     fn u16_max() {
         return u16(-1);
     };
-    
+
     /**
         Returns the minimum value that can be stored in a `s16`.
         @return Minimum value
@@ -61,7 +61,7 @@ namespace auto std::limits {
     fn s16_min() {
         return -s16((std::limits::u16_max() / 2)) - 1;
     };
-    
+
     /**
         Returns the maximum value that can be stored in a `s16`.
         @return Maximum value
@@ -69,7 +69,7 @@ namespace auto std::limits {
     fn s16_max() {
         return s16((std::limits::u16_max() / 2));
     };
-    
+
     /**
         Returns the minimum value that can be stored in a `u32`.
         @return Minimum value
@@ -77,7 +77,7 @@ namespace auto std::limits {
     fn u32_min() {
         return u32(0);
     };
-    
+
     /**
         Returns the maximum value that can be stored in a `u32`.
         @return Maximum value
@@ -85,7 +85,7 @@ namespace auto std::limits {
     fn u32_max() {
         return u32(-1);
     };
-    
+
     /**
         Returns the minimum value that can be stored in a `s32`.
         @return Minimum value
@@ -93,7 +93,7 @@ namespace auto std::limits {
     fn s32_min() {
         return -s32((std::limits::u32_max() / 2)) - 1;
     };
-    
+
     /**
         Returns the maximum value that can be stored in a `s32`.
         @return Maximum value
@@ -101,7 +101,7 @@ namespace auto std::limits {
     fn s32_max() {
         return s32((std::limits::u32_max() / 2));
     };
-    
+
     /**
         Returns the minimum value that can be stored in a `u64`.
         @return Minimum value
@@ -109,7 +109,7 @@ namespace auto std::limits {
     fn u64_min() {
         return u64(0);
     };
-    
+
     /**
         Returns the maximum value that can be stored in a `u64`.
         @return Maximum value
@@ -117,7 +117,7 @@ namespace auto std::limits {
     fn u64_max() {
         return u64(-1);
     };
-    
+
     /**
         Returns the minimum value that can be stored in a `s64`.
         @return Minimum value
@@ -125,7 +125,7 @@ namespace auto std::limits {
     fn s64_min() {
         return -s64((std::limits::u64_max() / 2)) - 1;
     };
-    
+
     /**
         Returns the maximum value that can be stored in a `s64`.
         @return Maximum value
@@ -133,7 +133,7 @@ namespace auto std::limits {
     fn s64_max() {
         return s64((std::limits::u64_max() / 2));
     };
-    
+
     /**
         Returns the minimum value that can be stored in a `u128`.
         @return Minimum value
@@ -141,7 +141,7 @@ namespace auto std::limits {
     fn u128_min() {
         return u128(0);
     };
-    
+
     /**
         Returns the maximum value that can be stored in a `u128`.
         @return Maximum value
@@ -149,7 +149,7 @@ namespace auto std::limits {
     fn u128_max() {
         return u128(-1);
     };
-    
+
     /**
         Returns the minimum value that can be stored in a `s128`.
         @return Minimum value
@@ -157,7 +157,7 @@ namespace auto std::limits {
     fn s128_min() {
         return -s128((std::limits::u128_max() / 2)) - 1;
     };
-    
+
     /**
         Returns the maximum value that can be stored in a `s128`.
         @return Maximum value
@@ -165,5 +165,5 @@ namespace auto std::limits {
     fn s128_max() {
         return s128((std::limits::u128_max() / 2));
     };
-    
+
 }

--- a/includes/std/math.pat
+++ b/includes/std/math.pat
@@ -20,7 +20,7 @@ namespace auto std::math {
         else
             return b;
     };
-    
+
     /**
         Compares the values `a` and `b` with each other and returns the bigger of the two
         @param a First value
@@ -56,9 +56,9 @@ namespace auto std::math {
         @return `x` if `x` is positive, `-x` otherwise
     */
     fn abs(auto x) {
-        if (x < 0) 
+        if (x < 0)
             return -x;
-        else 
+        else
             return x;
     };
 
@@ -96,13 +96,13 @@ namespace auto std::math {
     */
     fn factorial(u128 x) {
         u128 result;
-        
+
         result = x;
         while (x > 1) {
             x = x - 1;
             result = result * x;
         }
-        
+
         return result;
     };
 
@@ -336,5 +336,5 @@ namespace auto std::math {
     fn accumulate(u128 start, u128 end, u128 valueSize, std::mem::Section section = 0, AccumulateOperation operation = AccumulateOperation::Add, std::mem::Endian endian = std::mem::Endian::Native) {
         return builtin::std::math::accumulate(start, end, valueSize, section, u128(operation), u128(endian));
     };
-    
+
 }

--- a/includes/std/mem.pat
+++ b/includes/std/mem.pat
@@ -66,7 +66,7 @@ namespace auto std::mem {
 
         return remainder != 0 ? value + (alignment - remainder) : value;
     };
-  
+
 
     /**
         Gets the base address of the data
@@ -261,7 +261,7 @@ namespace auto std::mem {
         From from_value;
         To to_value;
     };
-  
+
 
     /**
         Aligns the cursor to the given alignment
@@ -280,11 +280,11 @@ namespace auto std::mem {
     } [[sealed, format("std::mem::impl::format_bytes")]];
 
     namespace impl {
-      
+
         fn format_bytes(auto bytes) {
             return "";
         };
-      
+
     }
 
 }

--- a/includes/std/ptr.pat
+++ b/includes/std/ptr.pat
@@ -57,7 +57,7 @@ namespace auto std::ptr {
         // `pointerValue` is `no_unique_address` because we don't want to advance
         // the current memory location after reading the value of the pointer itself;
         // we want to examine the value at this address to determine what should be
-        // displayed. It's also `hidden` so the editor only displays either thee 
+        // displayed. It's also `hidden` so the editor only displays either thee
         // padding or the populated pointer/pointee field.
         PointerTy pointerValue [[no_unique_address, hidden]];
         if (pointerValue == 0x0) {

--- a/includes/std/random.pat
+++ b/includes/std/random.pat
@@ -7,7 +7,7 @@ import std.limits;
 */
 
 namespace auto std::random {
-  
+
     /**
         Represents the type of distribution to use to generate a random number
     */
@@ -68,7 +68,7 @@ namespace auto std::random {
         return builtin::std::random::generate(u32(distribution), param1, param2);
     };
 
-    
+
     /**
         Generates a uniformly distributed random number between `min` and `max`
         @param [min] Minimum number. Defaults to 0
@@ -77,5 +77,5 @@ namespace auto std::random {
     fn generate(u64 min = std::limits::u64_min(), u64 max = std::limits::u64_max()) {
         return std::random::generate_using(Distribution::Uniform, min, max);
     };
-  
+
 }

--- a/includes/std/string.pat
+++ b/includes/std/string.pat
@@ -165,16 +165,16 @@ namespace auto std::string {
         @param string The string to reverse.
         @return The reversed string.
     */
-    fn reverse(str string) {    
+    fn reverse(str string) {
         str result;
-        
+
         s32 i;
         i = std::string::length(string);
         while (i > 0) {
             i = i - 1;
             result = result + std::string::at(string, i);
         }
-            
+
         return result;
     };
 
@@ -185,23 +185,23 @@ namespace auto std::string {
     */
     fn to_upper(str string) {
         str result;
-        
+
         u32 i;
         char c;
         while (i < std::string::length(string)) {
             c = std::string::at(string, i);
-            
+
             if (c >= 'a' && c <= 'z')
                 result = result + char(c - 0x20);
             else
                 result = result + c;
-            
+
             i = i + 1;
         }
-        
+
         return result;
     };
-    
+
     /**
         Converts a string to lower case.
         @param string The string to convert.
@@ -209,20 +209,20 @@ namespace auto std::string {
     */
     fn to_lower(str string) {
         str result;
-        
+
         u32 i;
         char c;
         while (i < std::string::length(string)) {
             c = std::string::at(string, i);
-            
+
             if (c >= 'A' && c <= 'Z')
                 result = result + char(c + 0x20);
             else
                 result = result + c;
-            
+
             i = i + 1;
         }
-        
+
         return result;
     };
 

--- a/includes/type/byte.pat
+++ b/includes/type/byte.pat
@@ -8,7 +8,7 @@ import std.core;
 */
 
 namespace auto type {
-    
+
     /**
         Type visualizing the value of each individual bit
     */
@@ -22,7 +22,7 @@ namespace auto type {
         bit6 : 1;
         bit7 : 1;
     } [[format("type::impl::format_bits"), bitfield_order(std::core::BitfieldOrder::LeastToMostSignificant, 8)]];
-    
+
     /**
         Type visualizing the value of the two nibbles
     */
@@ -30,7 +30,7 @@ namespace auto type {
         low  : 4;
         high : 4;
     } [[format("type::impl::format_nibbles")]];
-    
+
     /**
         Type representing a single Byte. Decodes the byte as it's hexadecimal value, individual bits and nibbles
     */
@@ -50,9 +50,9 @@ namespace auto type {
                 byte.bits.bit0,
                 byte.bits.bit7);
         };
-        
+
         fn format_bits(Bits bits) {
-            return std::format("0b{}{}{}{}{}{}{}{}", 
+            return std::format("0b{}{}{}{}{}{}{}{}",
                 bits.bit7,
                 bits.bit6,
                 bits.bit5,
@@ -62,7 +62,7 @@ namespace auto type {
                 bits.bit1,
                 bits.bit0);
         };
-        
+
         fn format_nibbles(Nibbles nibbles) {
             return std::format("{{ {0:0X}, {1:0X} }}", nibbles.high, nibbles.low);
         };

--- a/includes/type/color.pat
+++ b/includes/type/color.pat
@@ -14,7 +14,7 @@ namespace auto type {
         @tparam R Number of bits used for the red component
         @tparam G Number of bits used for the green component
         @tparam B Number of bits used for the blue component
-        @tparam A Number of bits used for the alpha component 
+        @tparam A Number of bits used for the alpha component
     */
     bitfield RGBA<auto R, auto G, auto B, auto A> {
         r : R;
@@ -22,7 +22,7 @@ namespace auto type {
         b : B;
         if (A > 0) a : A;
     } [[sealed, format("type::impl::format_color"), color(std::format("{0:02X}{1:02X}{2:02X}FF", r, g, b))]];
-    
+
     /**
         Type representing a generic RGB color with a variable number of bits for each color
         @tparam R Number of bits used for the red component
@@ -30,7 +30,7 @@ namespace auto type {
         @tparam B Number of bits used for the blue component
     */
     using RGB<auto R, auto G, auto B> = RGBA<R,G,B,0>;
-    
+
 
     /**
         Type representing a RGBA color with 8 bits for the red component, 8 bits for green, 8 bits for blue and 8 bits for alpha
@@ -56,7 +56,7 @@ namespace auto type {
         Type representing a RGBA color with 5 bits for the red component, 5 bits for green, 5 bits for blue and 1 bits for alpha
     */
     using RGBA5551 = RGBA<5,5,5,1>;
-    
+
 
     namespace impl {
 
@@ -76,5 +76,5 @@ namespace auto type {
         };
 
     }
-    
+
 }

--- a/includes/type/float16.pat
+++ b/includes/type/float16.pat
@@ -9,14 +9,14 @@ import std.mem;
 */
 
 namespace auto type {
-    
+
     /**
         Type representing a 16 bit half precision floating point number
     */
     using float16 = u16 [[format("type::impl::format_float16")]];
 
     namespace impl {
-    
+
         union U32ToFloatConverter {
             u32 intValue;
             float floatValue;
@@ -26,20 +26,20 @@ namespace auto type {
             u32 sign = value >> 15;
             u32 exponent = (value >> 10) & 0x1F;
             u32 mantissa = value & 0x3FF;
-    
+
             u32 result = 0x00;
-    
+
             if (exponent == 0) {
                 if (mantissa == 0) {
                     result = sign << 31;
                 } else {
                     exponent = 0x7F - 14;
-    
+
                     while ((mantissa & (1 << 10)) == 0) {
                         exponent -= 1;
                         mantissa <<= 1;
                     }
-    
+
                     mantissa &= 0x3FF;
                     result = (sign << 31) | (exponent << 23) | (mantissa << 13);
                 }
@@ -48,10 +48,10 @@ namespace auto type {
             } else {
                 result = (sign << 31) | ((exponent + (0x7F - 15)) << 23) | (mantissa << 13);
             }
-            
+
             std::mem::Reinterpreter<u32, float> converter;
             converter.from = result;
-            
+
             return std::format("{}", converter.to);
         };
 

--- a/includes/type/guid.pat
+++ b/includes/type/guid.pat
@@ -29,7 +29,7 @@ namespace auto type {
 
         fn format_guid(GUID guid) {
             bool valid = ((le u16(guid.time_high_and_version) >> 12) <= 5) && (((guid.clock_seq_and_reserved >> 4) >= 8) || ((guid.clock_seq_and_reserved >> 4) == 0));
-    
+
             return std::format("{}{{{:08X}-{:04X}-{:04X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}}}",
                 valid ? "" : "Invalid ",
                 le u32(guid.time_low),

--- a/includes/type/leb128.pat
+++ b/includes/type/leb128.pat
@@ -8,7 +8,7 @@ import std.mem;
 */
 
 namespace auto type {
-    
+
     /**
         Base LEB128 type. Use `uLEB128` and `sLEB128` instead.
     */
@@ -30,9 +30,9 @@ namespace auto type {
         Legacy alias for uLEB128
     */
     using LEB128 = uLEB128;
-    
+
     namespace impl {
-    
+
         fn transform_uleb128_array(ref auto array) {
             u128 res = array[0] & 0x7f;
             for(u8 i = 1, array[i-1] & 0x80 != 0, i+=1) {
@@ -41,19 +41,19 @@ namespace auto type {
             return res;
         };
 
-        fn transform_sleb128_array(ref auto array) {            
+        fn transform_sleb128_array(ref auto array) {
             s128 res = type::impl::transform_uleb128_array(array);
             if (res & 0x40 != 0) {
                 res |= ~0 << (sizeof(array) / sizeof(u8)) * 7;
             }
             return res;
         };
-        
+
         fn format_uleb128(ref auto leb128) {
             u128 res = type::impl::transform_uleb128_array(leb128.array);
             return std::format("{} ({:#x})", res, res);
         };
-    
+
         fn transform_uleb128(ref auto leb128) {
             return type::impl::transform_uleb128_array(leb128.array);
         };
@@ -62,11 +62,11 @@ namespace auto type {
             s128 res = type::impl::transform_sleb128_array(leb128.array);
             return std::format("{} ({:#x})", res, res);
         };
-    
+
         fn transform_sleb128(ref auto leb128) {
             return type::impl::transform_sleb128_array(leb128.array);
         };
 
     }
-    
+
 }

--- a/includes/type/time.pat
+++ b/includes/type/time.pat
@@ -13,9 +13,9 @@ namespace auto type {
         A 32 bit Unix time value
     */
     using time32_t = u32 [[format("type::impl::format_time_t")]];
-    
+
     /**
-        Alias name for `time32_t` 
+        Alias name for `time32_t`
     */
     using time_t = time32_t;
 

--- a/patterns/3ds.hexpat
+++ b/patterns/3ds.hexpat
@@ -7,7 +7,7 @@ import type.base;
 #pragma MIME image/x-3ds
 
 // Heavily based off of ZiZi's 010 Editor 3DS Template
-enum ChunkIdentifier : u16 {    
+enum ChunkIdentifier : u16 {
     NULL_CHUNK                            = 0x0000,
     ChunkType                             = 0x0995,
     ChunkUnique                           = 0x0996,
@@ -40,10 +40,10 @@ enum ChunkIdentifier : u16 {
     COLOR_24                              = 0x0011, // r,g,b: Byte
     LIN_COLOR_24                          = 0x0012, // r,g,b: Byte (gamma corrected)
     LIN_COLOR_F                           = 0x0013, // r,g,b: Single precision float (gamma corrected)
-    
+
     INT_PERCENTAGE                        = 0x0030, // u16 integer
     FLOAT_PERCENTAGE                      = 0x0031, // Single precision float
-    
+
     M3DMAGIC                              = 0x4D4D,
     SMAGIC                                = 0x2D2D,
     LMAGIC                                = 0x2D3D,
@@ -72,7 +72,7 @@ enum ChunkIdentifier : u16 {
             RAY_BIAS                      = 0x1460,
             USE_RAYTRACE                  = 0x1470,
             O_CONSTS                      = 0x1500,
-    
+
             AMBIENT_LIGHT                 = 0x2100,
 
             FOG                           = 0x2200,
@@ -82,7 +82,7 @@ enum ChunkIdentifier : u16 {
             USE_DISTANCE_CUE              = 0x2301,
             WORLD_LAYERED_FOG             = 0x2302,
             WORLD_USE_LAYERED_FOG         = 0x2303,
-            
+
             DEFAULT_VIEW                  = 0x3000,
             VIEW_TOP                      = 0x3010,
             VIEW_BOTTOM                   = 0x3020,
@@ -93,7 +93,7 @@ enum ChunkIdentifier : u16 {
             VIEW_USER                     = 0x3070,
             VIEW_CAMERA                   = 0x3080,
             VIEW_WINDOW                   = 0x3090,
-            
+
             NAMED_OBJECT                  = 0x4000,
                 OBJ_HIDDEN                = 0x4010,
                 OBJ_VIS_LOFTER            = 0x4011,
@@ -103,7 +103,7 @@ enum ChunkIdentifier : u16 {
                 OBJ_PROCEDURAL            = 0x4015,
                 OBJ_FROZEN                = 0x4016,
                 OBJ_DONT_RCVSHADOW        = 0x4017,
-    
+
             N_TRI_OBJECT                  = 0x4100,
                 POINT_ARRAY               = 0x4110,
                 POINT_FLAG_ARRAY          = 0x4111,
@@ -134,7 +134,7 @@ enum ChunkIdentifier : u16 {
                     DL_SPOT_OVERSHOOT     = 0x4652,
                     DL_SPOT_PROJECTOR     = 0x4653,
                     DL_EXCLUDE            = 0x4654,
-                    DL_RANGE              = 0x4655, /* Not used in R3 */ 
+                    DL_RANGE              = 0x4655, /* Not used in R3 */
                     DL_SPOT_ROLL          = 0x4656,
                     DL_SPOT_ASPECT        = 0x4657,
                     DL_RAY_BIAS           = 0x4658,
@@ -143,22 +143,22 @@ enum ChunkIdentifier : u16 {
                 DL_INNER_RANGE            = 0x4659,
                 DL_OUTER_RANGE            = 0x465A,
                 DL_MULTIPLIER             = 0x465B,
-                
+
             N_AMBIENT_LIGHT               = 0x4680,
-        
+
             N_CAMERA                      = 0x4700,
             CAM_SEE_CONE                  = 0x4710,
             CAM_RANGES                    = 0x4720,
-            
+
             HIERARCHY                     = 0x4F00,
             PARENT_OBJECT                 = 0x4F10,
             PIVOT_OBJECT                  = 0x4F20,
             PIVOT_LIMITS                  = 0x4F30,
             PIVOT_ORDER                   = 0x4F40,
             XLATE_RANGE                   = 0x4F50,
-            
+
             POLY_2D                       = 0x5000,
-            
+
             /* Flags in shaper file that tell whether polys make up an ok shape */
             SHAPE_OK                      = 0x5010,
             SHAPE_NOT_OK                  = 0x5011,
@@ -177,8 +177,8 @@ enum ChunkIdentifier : u16 {
             YZ_CURVE                      = 0x6080,
             INTERPCT                      = 0x6090,
             DEFORM_LIMIT                  = 0x60A0,
-            
-            /* Flags for Modeler options */ 
+
+            /* Flags for Modeler options */
             USE_CONTOUR                   = 0x6100,
             USE_TWEEN                     = 0x6110,
             USE_SCALE                     = 0x6120,
@@ -187,7 +187,7 @@ enum ChunkIdentifier : u16 {
             USE_FIT                       = 0x6150,
             USE_BEVEL                     = 0x6160,
 
-            /* Viewport description chunks */ 
+            /* Viewport description chunks */
             VIEWPORT_LAYOUT_OLD           = 0x7000,
             VIEWPORT_DATA_OLD             = 0x7010,
             VIEWPORT_LAYOUT               = 0x7001,
@@ -196,7 +196,7 @@ enum ChunkIdentifier : u16 {
             VIEWPORT_SIZE                 = 0x7020,
             NETWORK_VIEW                  = 0x7030,
 
-            /* External Application Data */ 
+            /* External Application Data */
             XDATA_SECTION                 = 0x8000,
             XDATA_ENTRY                   = 0x8001,
             XDATA_APPNAME                 = 0x8002,
@@ -215,8 +215,8 @@ enum ChunkIdentifier : u16 {
             XDATA_RFU1                    = 0x800F,
 
             PARENT_NAME                   = 0x80F0,
-            
-            /* Material Chunk IDs */ 
+
+            /* Material Chunk IDs */
             MAT_ENTRY                     = 0xAFFF,
                 MAT_NAME                  = 0xA000,
                 MAT_AMBIENT               = 0xA010,
@@ -228,7 +228,7 @@ enum ChunkIdentifier : u16 {
                 MAT_TRANSPARENCY          = 0xA050,
                 MAT_XPFALL                = 0xA052,
                 MAT_REFBLUR               = 0xA053,
-                
+
                 MAT_SELF_ILLUM            = 0xA080,
                 MAT_TWO_SIDE              = 0xA081,
                 MAT_DECAL                 = 0xA082,
@@ -241,13 +241,13 @@ enum ChunkIdentifier : u16 {
                 MAT_XPFALLIN              = 0xA08A,
                 MAT_PHONGSOFT             = 0xA08C,
                 MAT_WIREABS               = 0xA08E,
-                
+
                 MAT_SHADING               = 0xA100,
-                
+
                 MAT_TEXMAP                = 0xA200,
                     MAT_MAPNAME           = 0xA300,
                     MAT_ACUBIC            = 0xA310,
-                    
+
                     MAT_MAP_TILINGOLD     = 0xA350,
                     MAT_MAP_TILING        = 0xA351,
                     MAT_MAP_TEXBLUR_OLD   = 0xA352,
@@ -262,14 +262,14 @@ enum ChunkIdentifier : u16 {
                     MAT_MAP_RCOL          = 0xA364,
                     MAT_MAP_GCOL          = 0xA366,
                     MAT_MAP_BCOL          = 0xA368,
-                    
+
                 MAT_SPECMAP               = 0xA204,
                 MAT_OPACMAP               = 0xA210,
                 MAT_REFLMAP               = 0xA220,
                 MAT_BUMPMAP               = 0xA230,
                 MAT_USE_REFBLUR           = 0xA250,
                 MAT_BUMP_PERCENT          = 0xA252,
-                
+
                 MAT_SXP_TEXT_DATA         = 0xA320,
                 MAT_SXP_TEXT2_DATA        = 0xA321,
                 MAT_SXP_OPAC_DATA         = 0xA322,
@@ -285,7 +285,7 @@ enum ChunkIdentifier : u16 {
                 MAT_SXP_SHIN_MASKDATA     = 0xA334,
                 MAT_SXP_SELFI_MASKDATA    = 0xA336,
                 MAT_SXP_REFL_MASKDATA     = 0xA338,
-                
+
                 MAT_TEX2MAP               = 0xA33A,
                 MAT_SHINMAP               = 0xA33C,
                 MAT_SELFIMAP              = 0xA33D,
@@ -297,8 +297,8 @@ enum ChunkIdentifier : u16 {
                 MAT_SPECMASK              = 0xA348,
                 MAT_SELFIMASK             = 0xA34A,
                 MAT_REFLMASK              = 0xA34C,
-                
-        /* Keyframe Chunk IDs */ 
+
+        /* Keyframe Chunk IDs */
         KFDATA                            = 0xB000,
             KFHDR                         = 0xB00A,
             AMBIENT_NODE_TAG              = 0xB001,
@@ -308,13 +308,13 @@ enum ChunkIdentifier : u16 {
             LIGHT_NODE_TAG                = 0xB005,
             L_TARGET_NODE_TAG             = 0xB006,
             SPOTLIGHT_NODE_TAG            = 0xB007,
-            
+
             KFSEG                         = 0xB008,
             KFCURTIME                     = 0xB009,
-            
+
                 NODE_HDR                  = 0xB010,
                 INSTANCE_NAME             = 0xB011,
-                PRESCALE                  = 0xB012, 
+                PRESCALE                  = 0xB012,
                 PIVOT                     = 0xB013,
                 BOUNDBOX                  = 0xB014,
                 MORPH_SMOOTH              = 0xB015,
@@ -329,10 +329,10 @@ enum ChunkIdentifier : u16 {
                 FALL_TRACK_TAG            = 0xB028,
                 HIDE_TRACK_TAG            = 0xB029,
                 NODE_ID                   = 0xB030,
-                
-    
+
+
 	CMAGIC                                = 0xC23D,
-    
+
         C_MDRAWER                         = 0xC010,
         C_TDRAWER                         = 0xC020,
         C_SHPDRAWER                       = 0xC030,
@@ -395,7 +395,7 @@ enum ChunkIdentifier : u16 {
         C_BITMAP_DRAWER                   = 0xC25B,
         C_RGB_FILE                        = 0xC260,
         C_RGB_OVASPECT                    = 0xC270,
-            
+
         C_RGB_ANIMTYPE                    = 0xC271,
         C_RENDER_ALL                      = 0xC272,
         C_REND_FROM                       = 0xC273,
@@ -513,16 +513,16 @@ enum ChunkIdentifier : u16 {
         C_VTR_IN                          = 0xC775,
         C_VTR_PK                          = 0xC780,
         C_VTR_SH                          = 0xC785,
-   
-/* Material chunks */ 
-        C_WORK_MTLS                       = 0xC790, /* Old-style -- now ignored */ 
-        C_WORK_MTLS_2                     = 0xC792, /* Old-style -- now ignored */ 
-        C_WORK_MTLS_3                     = 0xC793, /* Old-style -- now ignored */ 
-        C_WORK_MTLS_4                     = 0xC794, /* Old-style -- now ignored */ 
-        C_WORK_MTLS_5                     = 0xCB00, /* Old-style -- now ignored */ 
-        C_WORK_MTLS_6                     = 0xCB01, /* Old-style -- now ignored */ 
-        C_WORK_MTLS_7                     = 0xCB02, /* Old-style -- now ignored */ 
-        C_WORK_MTLS_8                     = 0xCB03, /* Old-style -- now ignored */ 
+
+/* Material chunks */
+        C_WORK_MTLS                       = 0xC790, /* Old-style -- now ignored */
+        C_WORK_MTLS_2                     = 0xC792, /* Old-style -- now ignored */
+        C_WORK_MTLS_3                     = 0xC793, /* Old-style -- now ignored */
+        C_WORK_MTLS_4                     = 0xC794, /* Old-style -- now ignored */
+        C_WORK_MTLS_5                     = 0xCB00, /* Old-style -- now ignored */
+        C_WORK_MTLS_6                     = 0xCB01, /* Old-style -- now ignored */
+        C_WORK_MTLS_7                     = 0xCB02, /* Old-style -- now ignored */
+        C_WORK_MTLS_8                     = 0xCB03, /* Old-style -- now ignored */
         C_WORKMTL                         = 0xCB04,
         C_SXP_TEXT_DATA                   = 0xCB10,
         C_SXP_TEXT2_DATA                  = 0xCB20,
@@ -542,15 +542,15 @@ enum ChunkIdentifier : u16 {
 
         C_BGTYPE                          = 0xC7A1,
         C_MEDTILE                         = 0xC7B0,
-   
+
 /* Contrast */
         C_LO_CONTRAST                     = 0xC7D0,
         C_HI_CONTRAST                     = 0xC7D1,
- 
-/* 3d frozen display */ 
+
+/* 3d frozen display */
         C_FROZ_DISPLAY                    = 0xC7E0,
- 
-/* Booleans */ 
+
+/* Booleans */
         C_BOOLWELD                        = 0xc7f0,
         C_BOOLTYPE                        = 0xc7f1,
 
@@ -569,8 +569,8 @@ enum ChunkIdentifier : u16 {
         C_MAPDRAWER8                      = 0xCA08,
         C_MAPDRAWER9                      = 0xCA09,
         C_MAPDRAWER_ENTRY                 = 0xCA10,
-   
-/* System Options */ 
+
+/* System Options */
         C_BACKUP_FILE                     = 0xCA20,
         C_DITHER_256                      = 0xCA21,
         C_SAVE_LAST                       = 0xCA22,
@@ -596,8 +596,8 @@ enum ChunkIdentifier : u16 {
         C_AUTO_SMOOTH                     = 0xCA80,
         C_DXF_SMOOTH_ANG                  = 0xCA90,
         C_SMOOTH_ANG                      = 0xCAA0,
-   
-/* Special network-use chunks */ 
+
+/* Special network-use chunks */
         C_NET_USE_VPOST                   = 0xCC00,
         C_NET_USE_GAMMA                   = 0xCC10,
         C_NET_FIELD_ORDER                 = 0xCC20,
@@ -628,8 +628,8 @@ enum ChunkIdentifier : u16 {
         C_VIEW_PRES_RATIO                 = 0xCE50,
         C_BGND_PRES_RATIO                 = 0xCE60,
         C_NTH_SERIAL_NUM                  = 0xCE70,
-   
-    /* Video Post */ 
+
+    /* Video Post */
     VPDATA                                = 0xd000,
 
         P_QUEUE_ENTRY                     = 0xd100,
@@ -648,7 +648,7 @@ enum ChunkIdentifier : u16 {
         P_QUEUE_ALIGN                     = 0xd190,
 
         P_CUSTOM_SIZE                     = 0xd1a0,
-     
+
         P_ALPH_NONE                       = 0xd210,
         P_ALPH_PSEUDO                     = 0xd220,  /* Old chunk */
         P_ALPH_OP_PSEUDO                  = 0xd221,  /* Old chunk */
@@ -732,7 +732,7 @@ bitfield Spline {
     Use_Bias       : 1;
     Use_Ease_To    : 1;
     Use_Ease_From  : 1;
-    
+
     padding : 3;
 
     if (Use_Tension == 1)
@@ -745,7 +745,7 @@ bitfield Spline {
         float Ease_To;
     if (Use_Ease_From == 1)
         float Ease_From;
-        
+
     padding : 8;
 };
 
@@ -795,7 +795,7 @@ struct Keys<auto identifier> {
         ) : {
             RotationKey data[count];
         }
-        
+
         (
             ChunkIdentifier::FOV_TRACK_TAG |
             ChunkIdentifier::ROLL_TRACK_TAG |
@@ -804,13 +804,13 @@ struct Keys<auto identifier> {
         ) : {
             AngleKey data[count];
         }
-        
+
         (
             ChunkIdentifier::MORPH_TRACK_TAG
         ) : {
             MorphKey data[count];
         }
-        
+
         (
             ChunkIdentifier::HIDE_TRACK_TAG
         ) : {
@@ -842,7 +842,7 @@ struct Chunk {
     u32 chunkSize;
     u32 dataLength = chunkSize - 6 [[export]];
     u32 chunkEnd = $ + dataLength;
-    
+
     if (chunkSize > 0) {
         std::print("{}", identifier);
         match (identifier) {
@@ -894,14 +894,14 @@ struct Chunk {
             ): {
                 Chunk chunks[while($ < chunkEnd)];
             }
-            
+
             (
                 ChunkIdentifier::M3D_VERSION |
                 ChunkIdentifier::MESH_VERSION
             ): {
                 u32 version;
             }
-            
+
             (
                 ChunkIdentifier::LO_SHADOW_BIAS         |
                 ChunkIdentifier::HI_SHADOW_BIAS         |
@@ -921,41 +921,41 @@ struct Chunk {
             ): {
                 float value;
             }
-            
+
             (
                 ChunkIdentifier::V_GRADIENT
             ) : {
                 float position;
                 Chunk chunks[while($ < chunkEnd)];
             }
-            
+
             (
                 ChunkIdentifier::NAMED_OBJECT
             ) : {
                 char name[];
                 Chunk chunks[while($ < chunkEnd)];
             }
-            
+
             (
                 ChunkIdentifier::POINT_ARRAY
             ) : {
                 u16 count;
                 Vector3f vectices[count] [[hex::visualize("3d", this, null)]];
             }
-            
+
             (
                 ChunkIdentifier::TEX_VERTS
             ) : {
                 u16 count;
                 Vector2f coords[count];
             }
-            
+
             (
                 ChunkIdentifier::MESH_MATRIX
             ) : {
                 Vector3f x, y, z, w;
             }
-            
+
             (
                 ChunkIdentifier::FACE_ARRAY
             ) : {
@@ -963,26 +963,26 @@ struct Chunk {
                 Face faces[count];
                 Chunk chunks[while($ < chunkEnd)];
             }
-            
+
             (
                 ChunkIdentifier::POINT_FLAG_ARRAY
             ) : {
                 u16 count;
                 VertexFlags flags[count];
             }
-            
+
             (
                 ChunkIdentifier::SMOOTH_GROUP
             ) : {
                 u32 groups[dataLength / sizeof(u32)];
             }
-            
+
             (
                 ChunkIdentifier::MESH_COLOR
             ) : {
                 u8 value;
             }
-            
+
             (
                 ChunkIdentifier::MSH_MAT_GROUP
             ) : {
@@ -990,7 +990,7 @@ struct Chunk {
                 u16 count;
                 u16 groups[count];
             }
-            
+
             (
                 ChunkIdentifier::KFHDR
             ) : {
@@ -998,25 +998,25 @@ struct Chunk {
                 char name[];
                 u32 animationLength;
             }
-            
+
             (
                 ChunkIdentifier::KFSEG
             ) : {
                 u32 start, end;
             }
-            
+
             (
                 ChunkIdentifier::KFCURTIME
             ) : {
                 u32 frameIndex;
             }
-            
+
             (
                 ChunkIdentifier::NODE_ID
             ) : {
                 type::Hex<u16> id;
             }
-            
+
             (
                 ChunkIdentifier::NODE_HDR
             ) : {
@@ -1026,47 +1026,47 @@ struct Chunk {
                 KeyFlags2 flags2;
                 type::Hex<u16> parentId;
             }
-            
+
             (
                 ChunkIdentifier::PIVOT
             ) : {
                 Vector3f value;
             }
-            
+
             (
                 ChunkIdentifier::BOUNDBOX
             ) : {
                 Vector3f min, max;
             }
-           
+
             (
                 ChunkIdentifier::COLOR_24 |
                 ChunkIdentifier::LIN_COLOR_24
             ) : {
                 RGB<u8> color;
             }
-            
+
             (
                 ChunkIdentifier::COLOR_F |
                 ChunkIdentifier::LIN_COLOR_F
             ) : {
                 RGB<float> color;
             }
-            
+
             (
                 ChunkIdentifier::INT_PERCENTAGE |
                 ChunkIdentifier::MAT_BUMP_PERCENT
             ) : {
                 u16 value;
             }
-            
+
             (
                 ChunkIdentifier::SHADOW_MAP_SIZE |
                 ChunkIdentifier::MAT_SHADING
             ) : {
                 u16 value;
             }
-            
+
             (
                 ChunkIdentifier::POS_TRACK_TAG    |
                 ChunkIdentifier::ROT_TRACK_TAG    |
@@ -1077,13 +1077,13 @@ struct Chunk {
                 ChunkIdentifier::MORPH_TRACK_TAG  |
                 ChunkIdentifier::HOT_TRACK_TAG    |
                 ChunkIdentifier::FALL_TRACK_TAG   |
-                ChunkIdentifier::HIDE_TRACK_TAG 
+                ChunkIdentifier::HIDE_TRACK_TAG
             ) : {
                 TrackFlags flags;
                 u8 unknown[8];
                 Keys<identifier> keys;
             }
-            
+
             (
                 ChunkIdentifier::INSTANCE_NAME |
                 ChunkIdentifier::BIT_MAP       |
@@ -1093,26 +1093,26 @@ struct Chunk {
             ) : {
                 char name[];
             }
-            
+
             (
                 ChunkIdentifier::MAT_MAP_TILING
             ) : {
                 u16 tiling;
             }
-            
+
             (
                 ChunkIdentifier::WORLD_VIEWPORT_SIZE
             ) : {
                 u16 x, y, w, h;
             }
-            
+
             (
                 ChunkIdentifier::N_DIRECT_LIGHT
             ) : {
                 Vector3f position;
                 Chunk chunks[while($ < chunkEnd)];
             }
-            
+
             (
                 ChunkIdentifier::DL_SPOTLIGHT
             ) : {
@@ -1120,16 +1120,16 @@ struct Chunk {
                 float hotspot, falloff;
                 Chunk chunks[while($ < chunkEnd)];
             }
-            
+
             (
                 ChunkIdentifier::N_CAMERA
             ) : {
                 Vector3f position, target;
                 float roll, fov;
             }
-            
-            
-            
+
+
+
             (_) : {
                 std::warning(std::format("Unhandled Chunk ID: {}, Skipping 0x{:04X} bytes", identifier, dataLength));
                 $ += dataLength;

--- a/patterns/7z.hexpat
+++ b/patterns/7z.hexpat
@@ -1,102 +1,102 @@
 #pragma description 7z Archive
 #pragma MIME application/x-7z-compressed
 
-import std.io; 
-import std.mem; 
-import std.math; 
+import std.io;
+import std.mem;
+import std.math;
 
 
-enum Type:u8{ 
-    startPosition = 0x00,       // Start position 
-    sizeStartHeader = 0x20,  // Size of start Header       
-}; 
+enum Type:u8{
+    startPosition = 0x00,       // Start position
+    sizeStartHeader = 0x20,  // Size of start Header
+};
 
-enum TypeB:u48{ 
-    sevenZipSignature = 0x1C27AFBC7A37,  // Defining 7z signature   
-};   
+enum TypeB:u48{
+    sevenZipSignature = 0x1C27AFBC7A37,  // Defining 7z signature
+};
 
-struct StartHeader { 
-    // File signature 
-    u48 signature  [[color("FF0000")] ];  
-    // Version format 
-    u16 formatVersion [[color("00FF00")]];  
-    // CRC start header 
-    u32 crcOfTheFollowing20Bytes [[color("0000FF")]]; 
-    // Relative offset of End Header 
-    u64 relativeOffsetEndHeader [[color("FFFF00")]]; 
-    // Length of End Header 
-    u64 theLengthOfEndHeader [[color("00FFFF")]];  
-    // CRC of End Ender 
-    u32 crcOftheEndHeader [[color("FF00FF")]]; 
-    // File size calculation 
-    u64 fileSize = relativeOffsetEndHeader + theLengthOfEndHeader + Type::sizeStartHeader; 
-    // Absolute offset calculation End Header 
-    u64 startEndHeader = relativeOffsetEndHeader +  Type::sizeStartHeader; 
-}; 
+struct StartHeader {
+    // File signature
+    u48 signature  [[color("FF0000")] ];
+    // Version format
+    u16 formatVersion [[color("00FF00")]];
+    // CRC start header
+    u32 crcOfTheFollowing20Bytes [[color("0000FF")]];
+    // Relative offset of End Header
+    u64 relativeOffsetEndHeader [[color("FFFF00")]];
+    // Length of End Header
+    u64 theLengthOfEndHeader [[color("00FFFF")]];
+    // CRC of End Ender
+    u32 crcOftheEndHeader [[color("FF00FF")]];
+    // File size calculation
+    u64 fileSize = relativeOffsetEndHeader + theLengthOfEndHeader + Type::sizeStartHeader;
+    // Absolute offset calculation End Header
+    u64 startEndHeader = relativeOffsetEndHeader +  Type::sizeStartHeader;
+};
 
-StartHeader startheader @ Type::startPosition; 
- 
-struct CompressedData { 
-     // Start of compressed data     
-     u8 startOfCompressedData[4] [[color("C0C0C0")]];          
-}; 
+StartHeader startheader @ Type::startPosition;
 
-CompressedData compresseddata @ Type::sizeStartHeader; 
+struct CompressedData {
+     // Start of compressed data
+     u8 startOfCompressedData[4] [[color("C0C0C0")]];
+};
 
-  
-struct EndHeader { 
-    // Set padding to place End Header in right position 
-    padding[startheader.relativeOffsetEndHeader]; 
-    // Mark link to meta block 
-    u8 linkToMetaBlock [[color("FF0000")]];     
-    // Mark all End Header 
-    char fullEndHeader[startheader.theLengthOfEndHeader] [[color("63954A")]];  
-    // Detect LZMA signature 
-    u64 lzmaSignaturePosition = std::mem::find_sequence_in_range(0, addressof(fullEndHeader), addressof(fullEndHeader) + sizeof(fullEndHeader), 0x23, 0x03, 0x01, 0x01, 0x05, 0x5D);    
-                                                 
-    // Mark positions if LZMA signature was detected 
-    if(lzmaSignaturePosition != 0xFFFFFFFFFFFFFFFF){ 
-        u48 lzmaSignature @ lzmaSignaturePosition [[color("0000FF")]];   
-    } 
-}; 
+CompressedData compresseddata @ Type::sizeStartHeader;
 
-EndHeader endheader @ Type::sizeStartHeader; 
- 
-// Check 7z type 
-if(startheader.signature ==  TypeB::sevenZipSignature){ 
-    std::print("It is a 7z File Type");  
-}else{ 
-    std::print("The file is not 7z type");  
-}  
 
-std::print("Format Version {} ",startheader.formatVersion);  
+struct EndHeader {
+    // Set padding to place End Header in right position
+    padding[startheader.relativeOffsetEndHeader];
+    // Mark link to meta block
+    u8 linkToMetaBlock [[color("FF0000")]];
+    // Mark all End Header
+    char fullEndHeader[startheader.theLengthOfEndHeader] [[color("63954A")]];
+    // Detect LZMA signature
+    u64 lzmaSignaturePosition = std::mem::find_sequence_in_range(0, addressof(fullEndHeader), addressof(fullEndHeader) + sizeof(fullEndHeader), 0x23, 0x03, 0x01, 0x01, 0x05, 0x5D);
 
-// Version verification 
-if(startheader.formatVersion ==  0x0400){ 
-    std::print("Major Version 0x00 || 0 -  Minor Version 0x04 || 4");  
-}    
+    // Mark positions if LZMA signature was detected
+    if(lzmaSignaturePosition != 0xFFFFFFFFFFFFFFFF){
+        u48 lzmaSignature @ lzmaSignaturePosition [[color("0000FF")]];
+    }
+};
 
-// Verification of the compressed method is LZMA, Bzip2 or LZMA2 
-if(compresseddata.startOfCompressedData[0] ==  Type::startPosition){  
-     std::print("Compressed Method LZMA");    
-}else if(compresseddata.startOfCompressedData[0] ==  0x42){  
-    std::print("Compressed Method Bzip2");    
-}else{  
-    std::print("Compressed Method LZMA2");    
-} 
+EndHeader endheader @ Type::sizeStartHeader;
 
-  
+// Check 7z type
+if(startheader.signature ==  TypeB::sevenZipSignature){
+    std::print("It is a 7z File Type");
+}else{
+    std::print("The file is not 7z type");
+}
 
-std::print("CRC Start Header 0x{:X}",startheader.crcOfTheFollowing20Bytes);     
+std::print("Format Version {} ",startheader.formatVersion);
 
-std::print("CRC End Header 0x{:X} ", startheader.crcOftheEndHeader);  
+// Version verification
+if(startheader.formatVersion ==  0x0400){
+    std::print("Major Version 0x00 || 0 -  Minor Version 0x04 || 4");
+}
 
-std::print("CompressedData length 0x{:X} || {} bytes ",startheader.relativeOffsetEndHeader, startheader.relativeOffsetEndHeader);  
+// Verification of the compressed method is LZMA, Bzip2 or LZMA2
+if(compresseddata.startOfCompressedData[0] ==  Type::startPosition){
+     std::print("Compressed Method LZMA");
+}else if(compresseddata.startOfCompressedData[0] ==  0x42){
+    std::print("Compressed Method Bzip2");
+}else{
+    std::print("Compressed Method LZMA2");
+}
 
-std::print("Relative Offset of End Header 0x{:X} || {} bytes",startheader.relativeOffsetEndHeader, startheader.relativeOffsetEndHeader);  
 
-std::print("Offset to start End Header 0x{:X} || {} bytes",startheader.startEndHeader,startheader.startEndHeader);  
 
-std::print("End Header length 0x{:X} || {} bytes",startheader.theLengthOfEndHeader,startheader.theLengthOfEndHeader);  
+std::print("CRC Start Header 0x{:X}",startheader.crcOfTheFollowing20Bytes);
 
-std::print("File size 0x{:X} || {} bytes",startheader.fileSize, startheader.fileSize); 
+std::print("CRC End Header 0x{:X} ", startheader.crcOftheEndHeader);
+
+std::print("CompressedData length 0x{:X} || {} bytes ",startheader.relativeOffsetEndHeader, startheader.relativeOffsetEndHeader);
+
+std::print("Relative Offset of End Header 0x{:X} || {} bytes",startheader.relativeOffsetEndHeader, startheader.relativeOffsetEndHeader);
+
+std::print("Offset to start End Header 0x{:X} || {} bytes",startheader.startEndHeader,startheader.startEndHeader);
+
+std::print("End Header length 0x{:X} || {} bytes",startheader.theLengthOfEndHeader,startheader.theLengthOfEndHeader);
+
+std::print("File size 0x{:X} || {} bytes",startheader.fileSize, startheader.fileSize);

--- a/patterns/Crashlvl.hexpat
+++ b/patterns/Crashlvl.hexpat
@@ -353,7 +353,7 @@ struct Object {
             u16 numOfMetafields;
             u8 metafields[numOfMetafields];
         }
-    } 
+    }
     else {
         u32 x;
         u32 y;

--- a/patterns/afe2.hexpat
+++ b/patterns/afe2.hexpat
@@ -52,8 +52,8 @@ std::assert(ctx.magic == ATMOSPHERE_REBOOT_TO_FATAL_MAGIC   ||
        ctx.magic == ATMOSPHERE_REBOOT_TO_FATAL_MAGIC_1 ||
        ctx.magic == ATMOSPHERE_REBOOT_TO_FATAL_MAGIC_0,
        "File is not a valid Atmosphere fatal error binary!");
-	   
-std::assert_warn(ctx.magic == ATMOSPHERE_REBOOT_TO_FATAL_MAGIC, 
+
+std::assert_warn(ctx.magic == ATMOSPHERE_REBOOT_TO_FATAL_MAGIC,
            "Atmosphere fatal error binary is for an older version!");
 
 

--- a/patterns/ar.hexpat
+++ b/patterns/ar.hexpat
@@ -15,7 +15,7 @@ struct ARFile {
 	char file_mode[8];
 	char file_size[10];
 	u16 end_marker;
-	
+
 	if (end_marker == 0x0A60) {
 		u8 data[std::string::parse_int(this.file_size, 10)];
 		padding[sizeof(data) & 1];

--- a/patterns/arm_cm_vtor.hexpat
+++ b/patterns/arm_cm_vtor.hexpat
@@ -40,21 +40,21 @@ VectorTable vector_table @ VTOR;
 
 fn main() {
 	u32 table_size = sizeof(vector_table);
-	
+
 	u32 default_handler_address = 0x00;
-	
+
 	for (u32 i = 4, i < table_size, i = i + 4) {
 		u32 occurrences = 0;
 		for (u32 j = 4, j < table_size, j = j + 4) {
 			if (std::mem::read_unsigned(i, 4) == std::mem::read_unsigned(j, 4)) {
 				occurrences = occurrences + 1;
-				
+
 				if (occurrences > 1)
 					default_handler_address = std::mem::read_unsigned(i, 4);
 			}
 		}
 	}
-	
+
 	if (default_handler_address != 0x00)
 		std::print("Default Handler implementation at 0x{:08X}", default_handler_address);
 };

--- a/patterns/bencode.hexpat
+++ b/patterns/bencode.hexpat
@@ -8,20 +8,20 @@ import std.mem;
 import std.string;
 
 namespace bencode {
-	
+
 	struct ASCIIDecimal {
 		char value[while(std::ctype::isdigit(std::mem::read_unsigned($, 1)))];
 	} [[sealed, format("bencode::format_ascii_decimal"), transform("bencode::format_ascii_decimal")]];
-	
+
 	fn format_ascii_decimal(ASCIIDecimal adsasd) {
 		return std::string::parse_int(adsasd.value, 10);
 	};
-	
+
 	enum Type : u8 {
 		Integer = 'i',
 		Dictionary = 'd',
 		List = 'l',
-		
+
 		String0 = '0',
 		String1 = '1',
 		String2 = '2',
@@ -33,30 +33,30 @@ namespace bencode {
 		String8 = '8',
 		String9 = '9'
 	};
-	
+
 	struct String {
 		ASCIIDecimal length;
 		char separator [[hidden]];
 		char value[length];
 	} [[sealed, format("bencode::format_string"), transform("bencode::format_string")]];
-	
+
 	fn format_string(String string) {
-		return string.value; 
+		return string.value;
 	};
-	
+
 	using Bencode;
 	using Value;
-	
+
 	struct DictionaryEntry {
 		String key;
 		Value value;
 	};
-	
+
 	struct Value {
 		Type type;
-		
+
 		if (type == Type::Dictionary) {
-			DictionaryEntry entry[while(std::mem::read_unsigned($, 1) != 'e')];			
+			DictionaryEntry entry[while(std::mem::read_unsigned($, 1) != 'e')];
 		} else if (type == Type::Integer) {
 			ASCIIDecimal value;
 			char end;
@@ -65,12 +65,12 @@ namespace bencode {
 			String value;
 		}
 	};
-	
+
 	struct Bencode {
-		Value value[while(!std::mem::eof())] [[inline]];		
+		Value value[while(!std::mem::eof())] [[inline]];
 		char end;
 	};
-	
+
 }
 
 bencode::Bencode bencode @ 0x00;

--- a/patterns/bgcode.hexpat
+++ b/patterns/bgcode.hexpat
@@ -43,7 +43,7 @@ struct Header {
 
 Header header @ 0;
 std::assert(header.version == 1, "only version 1 supported");
-    
+
 struct Block {
     BlockType type;
     Compression compression;

--- a/patterns/blend.hexpat
+++ b/patterns/blend.hexpat
@@ -36,7 +36,7 @@ struct BHead<Ptr> {
     char code[4];
     s32 len;
     Ptr old;
-    s32 SDNAnr; 
+    s32 SDNAnr;
     s32 nr;
 
     // ENDB marks the last data block in the file.
@@ -137,7 +137,7 @@ struct BlendWrapper {
 
 BlendWrapper blendWrapper @ 0x00;
 
-// Assume the blend file is ZSTD compressed. 
+// Assume the blend file is ZSTD compressed.
 
 struct SeekTableFooter {
     u32 numFrames;

--- a/patterns/bmp.hexpat
+++ b/patterns/bmp.hexpat
@@ -97,7 +97,7 @@ struct Bitmap {
 		(_):   BitmapInfoHeaderV1 bmih;
 	}
 	padding[bmih.biSize - sizeof(bmih)];
-	
+
 	if (bmih.biBitCount <= 8)
 	{
 		if (bmih.biClrUsed > 0 )
@@ -105,7 +105,7 @@ struct Bitmap {
 		else
 			Colors rgbq[1 << bmih.biBitCount];
 	}
-	
+
 	if (bmih.biSizeImage > 0 )
 		u8 lineData[bmih.biSizeImage];
 	else

--- a/patterns/bplist.hexpat
+++ b/patterns/bplist.hexpat
@@ -29,14 +29,14 @@ enum Marker : u8 {
     UNK_0xF0 = 0xF0
 };
 
-fn get_marker_name(u8 marker) {    
+fn get_marker_name(u8 marker) {
     if (marker == Marker::Null){//    null	0000 0000
         return "Null ";
     }else if (marker == Marker::False){ //bool	0000 1000			// false
         return "False";
     }else if (marker == Marker::True){//bool	0000 1001			// true
         return "True";
-    }else if (marker == Marker::Fill){ //fill	0000 1111			// fill byte  
+    }else if (marker == Marker::Fill){ //fill	0000 1111			// fill byte
         return "Fill";
     }else if (marker & 0xF0 == Marker::Int){ //int	0001 nnnn	...		// # of bytes is 2^nnnn, big-endian bytes
         return "Int";
@@ -45,10 +45,10 @@ fn get_marker_name(u8 marker) {
     }else if (marker == Marker::Date){ //date	0011 0011	...		// 8 byte float follows, big-endian bytes
         return "Date";
     }else if (marker & 0xF0 == Marker::Data){ //data	0100 nnnn	[int]	...	// nnnn is number of bytes unless 1111 then int count follows, followed by bytes
-        return "Data";   
+        return "Data";
     }else if (marker & 0xF0 == Marker::ASCIIString){ //string	0101 nnnn	[int]	...	// ASCII string, nnnn is # of chars, else 1111 then int count, then bytes
         return "ASCIIString";
-    }else if (marker & 0xF0 == Marker::Unicode16String){ //string	0110 nnnn	[int]	...	// Unicode string, nnnn is # of chars, else 1111 then int count, then big-endian 2-byte 
+    }else if (marker & 0xF0 == Marker::Unicode16String){ //string	0110 nnnn	[int]	...	// Unicode string, nnnn is # of chars, else 1111 then int count, then big-endian 2-byte
         return "Unicode16String";
     }else if (marker & 0xF0 == Marker::UNK_0x70){ //0111 xxxx			// unused
         return "UNK_0x70";
@@ -56,19 +56,19 @@ fn get_marker_name(u8 marker) {
         return "UID";
     }else if (marker & 0xF0 == Marker::UNK_0x90){ // 1001 xxxx			// unused
         return "UNK_0x90";
-    }else if (marker & 0xF0 == Marker::Array){ //array	1010 nnnn	[int]	objref*	// nnnn is count, unless '1111', then int count follows        
+    }else if (marker & 0xF0 == Marker::Array){ //array	1010 nnnn	[int]	objref*	// nnnn is count, unless '1111', then int count follows
         return "Array";
     }else if (marker & 0xF0 == Marker::UNK_0xB0){ //1011 xxxx			// unused
         return "UNK_0xB0";
     }else if (marker & 0xF0 == Marker::Set){ //set	1100 nnnn	[int]	objref* // nnnn is count, unless '1111', then int count follows
         return "Set";
-    }else if (marker & 0xF0 == Marker::Dict){ //dict	1101 nnnn	[int]	keyref* objref*	// nnnn is count, unless '1111', then int count follows	
+    }else if (marker & 0xF0 == Marker::Dict){ //dict	1101 nnnn	[int]	keyref* objref*	// nnnn is count, unless '1111', then int count follows
         return "Dict";
     }else if (marker & 0xF0 == Marker::UNK_0xE0){ // 1110 xxxx			// unused
         return "UNK_0xE0";
     }else if (marker & 0xF0 == Marker::UNK_0xF0){  //1111 xxxx			// unused
         return "UNK_0xF0";
-    }    
+    }
 };
 
 fn format_tag(u8 marker) {
@@ -79,12 +79,12 @@ fn coredata_to_date (double val){
     return type::impl::format_time_t(978307200 + val);
 };
 
-struct DictElement {  
+struct DictElement {
     CFBinaryPlistObject key @ offsetTable[parent.objReference.key_refs[std::core::array_index()]].offset;
     CFBinaryPlistObject value @ offsetTable[parent.objReference.value_refs[std::core::array_index()]].offset;
 };
 
-struct ArrayElement {  
+struct ArrayElement {
     CFBinaryPlistObject value @ offsetTable[parent.objReference.value_refs[std::core::array_index()]].offset;
 };
 
@@ -142,23 +142,23 @@ struct CFBinaryPlistOffset{
 
 struct CFBinaryPlistObject{
     u8 marker [[format("get_marker_name")]];
-    
+
     u8 marker_msb = marker & 0xF0;
     u8 marker_lsb  = marker & 0x0F;
 
-    match (marker_msb){ 
+    match (marker_msb){
         (0x0): {
                 match (marker_lsb){
                     (Marker::Null): {
                         u8 value = 0x00 [[export]];
                     }
-                    (Marker::False): { 
+                    (Marker::False): {
                         bool value = false [[export]];
                     }
                     (Marker::True): {
                         bool value = true [[export]];
                     }
-                    (Marker::Fill): {  
+                    (Marker::Fill): {
                         //I think the correct implementation is to do nothing here. The marker will be used as padding (Fill) ???
                     }
                     (_): {
@@ -167,7 +167,7 @@ struct CFBinaryPlistObject{
                 }
         }
         (Marker::Int): {
-            be u8 size = std::math::pow(2, marker_lsb);     
+            be u8 size = std::math::pow(2, marker_lsb);
             // in format version '00', 1, 2, and 4-byte integers have to be interpreted as unsigned,
             // whereas 8-byte integers are signed (and 16-byte when available)
             // negative 1, 2, 4-byte integers are always emitted as 8 bytes in format '00'
@@ -181,10 +181,10 @@ struct CFBinaryPlistObject{
                 (8): be s64 value;
                 (16): be s128 value;
                 (_): std::error(std::format("Invalid size detected for 'Int' marker. Got size: {}.", size));
-            }                    
+            }
         }
         (Marker::Real): {
-            be u8 size = std::math::pow(2, marker_lsb); 
+            be u8 size = std::math::pow(2, marker_lsb);
             match (size){
                 (4): be float value;
                 (8): be double value;
@@ -196,7 +196,7 @@ struct CFBinaryPlistObject{
         }
         (Marker::Data): {
             ObjectLen ObjectLen;
-            u8 value[ObjectLen.size];      
+            u8 value[ObjectLen.size];
         }
         (Marker::ASCIIString): {
             ObjectLen ObjectLen;
@@ -216,7 +216,7 @@ struct CFBinaryPlistObject{
                 (8): be u64 value;
                 (16): be u128 value;
                 (_): std::error(std::format("Invalid size detected for 'UID' marker. Got size: {}.", size));
-            }      
+            }
         }
         (Marker::Set | Marker::Array): {
             ObjectLen ObjectLen;
@@ -226,7 +226,7 @@ struct CFBinaryPlistObject{
         }
         (Marker::Dict): {
             ObjectLen ObjectLen;
-            
+
             ObjectReference objReference;
             DictElement value[ObjectLen.size];
         }
@@ -235,7 +235,7 @@ struct CFBinaryPlistObject{
         }
         (_): {
             std::error(std::format("Got unknown marker 0x{:x}", marker));
-        }    
+        }
     }
 };
 
@@ -249,13 +249,13 @@ struct CFBinaryPlistHeader{
 
 struct CFBinaryPlistTrailer {
     u8 unused[5];
-    u8 sortVersion; 
+    u8 sortVersion;
     be u8 offsetIntSize;
     match (offsetIntSize){
         (1|2|4|8): {}
         (_): {std::error("Invalid offsetIntSize.");}
     }
-    be u8 objectRefSize; 
+    be u8 objectRefSize;
     match (objectRefSize){
         (1|2|4|8): {}
         (_): {std::error("Invalid objectRefSize.");}

--- a/patterns/bson.hexpat
+++ b/patterns/bson.hexpat
@@ -26,8 +26,8 @@ enum Type : u8 {
     Timestamp           = 0x11,
     Int64               = 0x12,
     Decimal128          = 0x13,
-    
-    MinKey              = 0xFF, 
+
+    MinKey              = 0xFF,
     MaxKey              = 0x7F
 };
 
@@ -78,9 +78,9 @@ using Document;
 
 struct Element {
     Type type;
-    
+
     CString name;
-    
+
     if (type == Type::Double) {
         double value;
     } else if (type == Type::String) {
@@ -93,9 +93,9 @@ struct Element {
         Binary value;
     } else if (type == Type::Undefined) {
         /* undefined */
-    } else if (type == Type::ObjectId) { 
+    } else if (type == Type::ObjectId) {
         ObjectId value;
-    } else if (type == Type::Boolean) { 
+    } else if (type == Type::Boolean) {
         bool value;
     } else if (type == Type::UTCDatetime) {
         type::time64_t value;

--- a/patterns/bsp_goldsrc.hexpat
+++ b/patterns/bsp_goldsrc.hexpat
@@ -163,7 +163,7 @@ struct dmiptexlump_t
 	MiptexPointer dataofs[nummiptex];
 };
 
-struct VisibilityData 
+struct VisibilityData
 {
 	u8 data[file_header.lumps[LumpIndex::Visibility].filelen];
 	u8 pad[std::mem::align_to(4, sizeof(this)) - sizeof(this)];

--- a/patterns/chm.hexpat
+++ b/patterns/chm.hexpat
@@ -285,26 +285,26 @@ struct DirectoryIndexEntry {
 
 struct ListingChunk {
     char magic[4];
-    
+
     if (magic == "PMGL") {
         type::Size<u32> freeSpaceLength;
         u32;
         u32 prevChunkNumber, nextChunkNumber;
-        
+
         u16 directoryListingEntryCount @ addressof(this) + parent.directoryChunkSize - 2;
         u16 offsets[(freeSpaceLength - 2) / 2] @ addressof(directoryListingEntryCount) - (freeSpaceLength - 2);
-        
+
         DirectoryListingEntry directories[directoryListingEntryCount];
-        
+
         $ = addressof(directoryListingEntryCount) + sizeof(directoryListingEntryCount);
     } else if (magic == "PMGI") {
         type::Size<u32> freeSpaceLength;
-        
+
         u16 directoryIndexEntryCount @ addressof(this) + parent.directoryChunkSize - 2;
         u16 offsets[(freeSpaceLength - 2) / 2] @ addressof(directoryIndexEntryCount) - (freeSpaceLength - 2);
-        
+
         DirectoryIndexEntry indexes[directoryIndexEntryCount];
-        
+
         $ = addressof(directoryIndexEntryCount) + sizeof(directoryIndexEntryCount);
     } else {
         std::error("Invalid chunk magic!");
@@ -313,7 +313,7 @@ struct ListingChunk {
 
 struct HeaderSection {
     char magic[4];
-    
+
     if (magic == "\xFE\x01\x00\x00") {
         u32;
         type::Size<u64> fileSize;
@@ -337,7 +337,7 @@ struct HeaderSection {
         u32;
         u32;
         u32;
-        
+
         ListingChunk chunk[directoryChunkCount];
     } else {
         std::error("Invalid header section magic!");
@@ -347,22 +347,22 @@ struct HeaderSection {
 struct HeaderSectionTableEntry {
     u64 offset;
     type::Size<u64> size;
-    
+
     HeaderSection headerSection @ offset;
 };
 
 struct NameListEntry {
     type::Size<u16> nameLength;
-    char16 name[nameLength];  
+    char16 name[nameLength];
     padding[2];
 };
 
 struct NameListFile {
     u16 fileLengthWords;
     u16 entriesInFile;
-    
+
     NameListEntry nameList[entriesInFile];
-    
+
     padding[0x2E];
 };
 
@@ -376,7 +376,7 @@ struct SectionData {
     u32;
 };
 
-struct Content {    
+struct Content {
     NameListFile nameListFile;
     SectionData sectionData;
 };
@@ -389,9 +389,9 @@ struct CHM {
     be u32 timeStamp;
     WindowsLanguageId languageId;
     type::GUID guids[2];
-    
+
     HeaderSectionTableEntry headerSectionTable[2];
-    
+
     Content *dataOffset : u64;
 };
 

--- a/patterns/coff.hexpat
+++ b/patterns/coff.hexpat
@@ -116,11 +116,11 @@ struct SymbolTable {
     Type type;
     StorageClass storageClass;
     u8 numberOfAuxSymbols;
-    
+
     countedSymbols += 1 + numberOfAuxSymbols;
-    
+
     AuxSymbol auxSymbols[numberOfAuxSymbols];
-    
+
     if (countedSymbols >= parent.header.numberOfSymbols)
         break;
 };
@@ -187,7 +187,7 @@ struct Section {
     u16 numberOfRelocations;
     u16 numberOfLineNumbers;
     SectionFlags characteristics;
-    
+
     u8 rawData[sizeOfRawData] @ pointerToRawData [[sealed]];
     Relocations relocations[numberOfRelocations] @ pointerToRelocations;
 };
@@ -205,9 +205,9 @@ struct Header {
 
 struct COFF {
     Header header;
-    
+
     Section sectionTable[header.numberOfSections];
-    
+
     SymbolTable symbolTable[header.numberOfSymbols] @ header.pointerToSymbolTable;
     StringTable stringTable @ addressof(symbolTable) + sizeof(symbolTable);
 };

--- a/patterns/cpio.hexpat
+++ b/patterns/cpio.hexpat
@@ -42,7 +42,7 @@ namespace old_binary {
             std::core::set_endian(std::mem::Endian::Little);
         else
             std::error("Invalid CPIO Magic!");
-        
+
         u16 dev;
         u16 ino;
         Mode mode;
@@ -59,7 +59,7 @@ namespace old_binary {
         CpioHeader header;
         char pathname[header.namesize % 2 == 0 ? header.namesize : header.namesize + 1];
         u8 data[header.filesize % 2 == 0 ? header.filesize : header.filesize + 1];
-        
+
         if (pathname == "TRAILER!!!\x00\x00")
             break;
     };

--- a/patterns/dds.hexpat
+++ b/patterns/dds.hexpat
@@ -203,7 +203,7 @@ enum DX10AlphaMode : u32 {
   Straight,
   PreMultiplied,
   Opaque,
-  Custom,	
+  Custom,
 };
 
 bitfield DX10MiscFlags {

--- a/patterns/dex.hexpat
+++ b/patterns/dex.hexpat
@@ -99,7 +99,7 @@ enum access_flag : type::uLEB128{
     static = 0x8,
     final = 0x10,
     synchronized = 0x20,
-    volatile = 0x40    
+    volatile = 0x40
 };
 
 struct encoded_field {
@@ -134,7 +134,7 @@ struct class_def_item {
     u32 class_data_off;
     //class_data_item *class_data_off:u32;
     u32 static_values_off;
-    char class_name[] @ addressof(parent.type_ids[class_idx].type_name);    
+    char class_name[] @ addressof(parent.type_ids[class_idx].type_name);
 }[[name(class_name)]];
 
 struct type_item {

--- a/patterns/dsstore.hexpat
+++ b/patterns/dsstore.hexpat
@@ -7,11 +7,11 @@ import std.io;
 struct RecordEntry {
   u32 length;
   char16 filename[length];
-  
+
   char id[4];
   // either blob or length
   char type[4];
-  
+
   if (type == "blob") {
     u32 blobCount;
     u8 blobData[blobCount];
@@ -67,15 +67,15 @@ struct BuddyBlock {
   u8 reserved[4];
   // padding for next multiple of 256 entries (1024 bytes)
   u32 addresses[blockCount];
-  
+
   // u8 padding[paddingCount];
   u32 directoryCount;
-  
+
   // directory entries
   u8 count;
   u8 name[count];
   u32 blockNumber;
-  
+
   // free lists
   // 32 free lists
   BuddyRootBlockOffsets off[32];
@@ -96,7 +96,7 @@ struct BuddyAllocator {
   u32 offsetBookkeeping2;
   u32 offsetData;
   u8 reserved[12];
-  
+
   BuddyRootBlock root @ offsetBookkeeping + 4;
 
   std::print("TOC {} address 0x{:08x}",
@@ -104,7 +104,7 @@ struct BuddyAllocator {
     root.offsets.addresses[root.toc.toc[0].value] >> 0x5 << 0x5);
 
   BlocksList blocks @ (root.offsets.addresses[root.toc.toc[0].value] >> 0x5 << 0x5) + 4;
-  
+
   std::print("Blocks start at address 0x{:08x}, size 0x{:04x}",
     root.offsets.addresses[blocks.blockId] >> 0x5 << 0x5,
     1 << (root.offsets.addresses[blocks.blockId] & 0x1f));

--- a/patterns/dted.hexpat
+++ b/patterns/dted.hexpat
@@ -7,11 +7,11 @@ import std.mem;
 import std.string;
 
 
-enum Magic:u24 { 
+enum Magic:u24 {
     UHL = 0x55484C,
     DSI = 0x445349,
     ACC = 0x414343,
-}; 
+};
 
 struct UHL {
     Magic magic;
@@ -95,7 +95,7 @@ struct ACC {
     ACCSub subs[9];
     char reserved4[18];
     char reserved5[69];
-    
+
 };
 
 struct DataRecords {

--- a/patterns/elf.hexpat
+++ b/patterns/elf.hexpat
@@ -651,7 +651,7 @@ struct Elf32_Shdr {
 			u8 data[sh_size] @ sh_offset [[sealed]];
 		}
     }
-} [[format("format_section_header")]];;
+} [[format("format_section_header")]];
 
 struct Elf64_Chdr {
     u32 ch_type;

--- a/patterns/elf.hexpat
+++ b/patterns/elf.hexpat
@@ -10,6 +10,7 @@
 import std.core;
 import std.io;
 import std.mem;
+import type.magic;
 
 using BitfieldOrder = std::core::BitfieldOrder;
 
@@ -515,7 +516,7 @@ bitfield PF {
 };
 
 struct E_IDENT {
-    char EI_MAG[4];
+    type::Magic<"\x7fELF"> EI_MAG;
     EI_CLASS EI_CLASS;
     EI_DATA EI_DATA;
     EI_VERSION EI_VERSION;

--- a/patterns/elf.hexpat
+++ b/patterns/elf.hexpat
@@ -565,7 +565,7 @@ struct Elf32_Phdr {
     Elf32_Word p_memsz;
     PF p_flags;
     Elf32_Word p_align;
-    
+
     if (p_offset >= 0 && p_filesz > 0 && (p_offset + p_filesz) <= std::mem::size() && p_filesz <= std::mem::size())
         u8 p_data[p_filesz] @ p_offset [[sealed]];
 };
@@ -579,7 +579,7 @@ struct Elf64_Phdr {
     Elf64_Xword p_filesz;
     Elf64_Xword p_memsz;
     Elf64_Xword p_align;
-    
+
     if (p_offset >= 0 && p_filesz > 0 && (p_offset + p_filesz) <= std::mem::size() && p_filesz <= std::mem::size())
         u8 p_data[p_filesz] @ p_offset [[sealed]];
 };
@@ -636,13 +636,13 @@ struct Elf32_Shdr {
     Elf32_Word sh_info;
     Elf32_Word sh_addralign;
     Elf32_Word sh_entsize;
-    
+
     if (sh_size > 0 && sh_offset + sh_size < std::mem::size()) {
     	if (sh_type == SHT::NOBITS || sh_type == SHT::NULL) {
 		// Section has no data
 		} else if (sh_type == SHT::STRTAB) {
 			String stringTable[while($ < (sh_offset + sh_size))] @ sh_offset;
-			stringTableIndex = std::core::array_index();	
+			stringTableIndex = std::core::array_index();
 		} else if (sh_type == SHT::SYMTAB || sh_type == SHT::DYNSYM) {
 			Elf32_Sym symbolTable[sh_size / sh_entsize] @ sh_offset;
 		} else if (sh_type == SHT::INIT_ARRAY || sh_type == SHT::FINI_ARRAY) {
@@ -696,13 +696,13 @@ struct Elf64_Shdr {
     Elf64_Word sh_info;
     Elf64_Xword sh_addralign;
     Elf64_Xword sh_entsize;
-    
+
     if (sh_size > 0 && sh_offset + sh_size < std::mem::size()) {
     	if (sh_type == SHT::NOBITS || sh_type == SHT::NULL) {
 			// Section has no data
 		} else if (sh_type == SHT::STRTAB) {
 			String stringTable[while($ < (sh_offset + sh_size))] @ sh_offset;
-			stringTableIndex = std::core::array_index();	
+			stringTableIndex = std::core::array_index();
 		} else if (sh_type == SHT::SYMTAB || sh_type == SHT::DYNSYM) {
 			Elf64_Sym symbolTable[sh_size / sh_entsize] @ sh_offset;
 		} else if (sh_type == SHT::INIT_ARRAY || sh_type == SHT::FINI_ARRAY) {
@@ -715,7 +715,7 @@ struct Elf64_Shdr {
 
 fn format_section_header(auto shdr) {
 	u32 i = 0;
-	
+
 	u32 nameAddress = addressof(elf.shdr[stringTableIndex].stringTable) + shdr.sh_name;
 	String string @ nameAddress;
 
@@ -725,12 +725,12 @@ fn format_section_header(auto shdr) {
 
 struct ELF {
 	E_IDENT e_ident;
-	
+
 	if (e_ident.EI_DATA == EI_DATA::ELFDATA2LSB)
 		std::core::set_endian(std::mem::Endian::Little);
 	else
 		std::core::set_endian(std::mem::Endian::Big);
-	
+
 	if (e_ident.EI_CLASS == EI_CLASS::ELFCLASS32) {
 		Elf32_Ehdr ehdr;
 		Elf32_Phdr phdr[ehdr.e_phnum] @ ehdr.e_phoff;

--- a/patterns/ext4.hexpat
+++ b/patterns/ext4.hexpat
@@ -211,7 +211,7 @@ struct ext4_super_block {
                 u32 s_journal_dev [[comment("Device number of journal file.")]];
             } else {
                 padding[4];
-            }   
+            }
         } else {
             padding[24];
         }
@@ -277,7 +277,7 @@ struct ext4_super_block {
         } else {
             padding[10];
         }
-        
+
         u32 s_raid_stripe_width [[comment("RAID stripe width. This is the number of logical blocks read from or written to the disk before coming back to the current disk.")]];
 
         if (s_feature_incompat.INCOMPAT_FLEX_BG) {
@@ -304,7 +304,7 @@ struct ext4_super_block {
         } else {
             padding[20];
         }
-        
+
         u32 s_error_count [[comment("Number of errors seen.")]];
         if (s_error_count > 0) {
             type::time32_t s_first_error_time [[comment("First time an error happened.")]];
@@ -329,7 +329,7 @@ struct ext4_super_block {
         } else {
             padding[8];
         }
-        
+
         u32 s_overhead_blocks [[comment("Overhead blocks/clusters in fs. (Huh? This field is always zero, which means that the linux kernel calculates it dynamically.)")]];
 
         if (s_feature_compat.COMPAT_SPARSE_SUPER2) {

--- a/patterns/flac.hexpat
+++ b/patterns/flac.hexpat
@@ -22,7 +22,7 @@ enum BLOCK_TYPE : u8 {
 	VORBIS_COMMENT = 4,
 	CUESHEET = 5,
 	PICTURE = 6,
-	
+
 	INVALID = 127
 };
 
@@ -48,7 +48,7 @@ struct METADATA_BLOCK_STREAMINFO {
 	u24 minFrameSize, maxFrameSize;
 	STREAMINFO_FLAGS flags;
 	u128 md5Signature;
-	
+
 	bitsPerSample = flags.bitsPerSample;
 };
 
@@ -79,7 +79,7 @@ struct VORBIS_USER_COMMENT {
 struct METADATA_BLOCK_VORBIS_COMMENT {
 	le u32 vendorLength;
 	u8 vendor[vendorLength];
-	
+
 	le u32 userCommentListLength;
 	VORBIS_USER_COMMENT userCommentList[userCommentListLength];
 };
@@ -168,24 +168,24 @@ bitfield FRAME_HEADER_FLAGS {
 
 struct FRAME_HEADER {
 	FRAME_HEADER_FLAGS flags;
-	
+
 	sampleSize = flags.sampleSize;
-	
+
 	if (flags.blockingStrategy)
 		char16 sampleNumber[7];
 	else
 		char16 frameNumber[6];
-	
+
 	if (flags.blockSize == 0b0110)
 		u8 blockSize;
 	else if (flags.blockSize == 0b0111)
 		u16 blockSize;
-		
+
 	if (flags.sampleRate == 0b1100)
 		u8 sampleRate;
 	else if (flags.sampleRate == 0b1101 || flags.sampleRate == 0b1110)
 		u16 sampleRate;
-		
+
 	u8 crc8;
 };
 
@@ -248,8 +248,8 @@ struct RESIDUAL {
 		RESIDUAL_CODING_METHOD_PARTITIONED_RICE rice;
 	else if (parent.value.codingMethod == 0b01)
 		RESIDUAL_CODING_METHOD_PARTITIONED_RICE2 rice;
-		
-		
+
+
 	if ((parent.parent.header.type & 0b111) == 0b000)
 		u8 samples[(getBitsPerSample() * (parent.parent.parent.header.flags.blockSize - (parent.parent.header.type & 0b111))) / 8];
 	else if (std::core::array_index() != 0)
@@ -278,7 +278,7 @@ struct SUBFRAME_LPC {
 
 struct SUBFRAME {
 	SUBFRAME_HEADER header;
-	
+
 	if (header.type == 0b00000)
 		SUBFRAME_CONSTANT constant;
 	else if (header.type == 0b000001)
@@ -300,7 +300,7 @@ struct METADATA_BLOCK {
 	METADATA_BLOCK_HEADER header;
 	if (header.lastMetadataBlock)
 		break;
-	
+
 	if (header.blockType == BLOCK_TYPE::STREAMINFO)
 		METADATA_BLOCK_STREAMINFO data;
 	else if (header.blockType == BLOCK_TYPE::PADDING)

--- a/patterns/fs.hexpat
+++ b/patterns/fs.hexpat
@@ -46,25 +46,25 @@ namespace fat32 {
 		padding[12];
 		u32 trailSignature;
 	};
-	
+
 	bitfield SequenceNumber {
 		padding : 1;
 		lastLogical : 1;
 		padding : 1;
 		number : 5;
 	} [[bitfield_order(BitfieldOrder::MostToLeastSignificant, 8)]];
-	
+
 	enum EntryStatus : u8 {
 		Regular = 0x00,
 		DotEntry = 0x2E,
 		DeletedEntry = 0xE5
 	};
-	
+
 	union EntryStatusOrSequenceNumber {
 		EntryStatus entryStatus;
 		SequenceNumber sequenceNumber;
 	};
-	
+
 	bitfield Attributes {
 		readOnly : 1;
 		hidden : 1;
@@ -74,7 +74,7 @@ namespace fat32 {
 		archive : 1;
 		padding : 2;
 	} [[bitfield_order(BitfieldOrder::LeastToMostSignificant, 8)]];
-	
+
 	struct DirEntry {
 		char fileName[8];
 		char extension[3];
@@ -83,10 +83,10 @@ namespace fat32 {
 		u16 time, date;
 		u16 startingCluster;
 		u32 fileSize;
-		
+
 		u8 data[fileSize] @ startingCluster * bytesPerCluster;
 	};
-	
+
 	struct VFATDirEntry {
 		EntryStatusOrSequenceNumber entryStatusOrSequenceNumber;
 		char16 name1[5];
@@ -96,7 +96,7 @@ namespace fat32 {
 		char16 name2[6];
 		u16 startingCluster;
 		char16 name3[2];
-		
+
 		if (entryStatusOrSequenceNumber.sequenceNumber.number > 1)
 			VFATDirEntry nextLogicalEntry;
 		else
@@ -133,9 +133,9 @@ namespace fat32 {
 		char fsType[8];
 		u8 bootstrapCode[420];
 		u16 signature;
-		
+
 		bytesPerCluster = (sectorsPerCluster * 1024) * bytesPerSector;
-		
+
 		FSInfo fsInfo @ addressof(this) + fsInfoSector * bytesPerSector;
 		VFATDirEntry rootDirEntry @ addressof(this) + rootCluster * bytesPerCluster;
 	};
@@ -143,13 +143,13 @@ namespace fat32 {
 }
 
 struct PartitionEntry {
-	PartitionStatus status;	
+	PartitionStatus status;
 	CHS chsFirstSectorAddress;
 	PartitionType type;
 	CHS chsLastSectorAddress;
 	u32 lbaFirstSectorAddress;
 	u32 numSectors;
-	
+
 	if (type == PartitionType::EmptyPartitionEntry)
 		continue;
 	else if (type == PartitionType::FAT32_CHS || type == PartitionType::FAT32_LBA)

--- a/patterns/gb.hexpat
+++ b/patterns/gb.hexpat
@@ -35,7 +35,7 @@ namespace format {
 		}
 		return std::format("size: {}, banks: {}", type::impl::size_formatter(romSize), romBanks);
 	};
-	
+
 	fn ram_type(u8 ramType) {
 		u16 ramSize;
 		u16 ramBanks;
@@ -57,7 +57,7 @@ namespace format {
 		}
 		return std::format("size: {}, banks: {}", type::impl::size_formatter(ramSize), ramBanks);
 	};
-	
+
 	fn rom_features(u8 type) {
 		str result = "( ";
 		if (brandedROMFeatures) match(type) {
@@ -67,37 +67,37 @@ namespace format {
 		match(type) {
 			(0x00): result += "no_mbc";
 			(0x01): result += "mbc1";
-			(0x02): result += "mbc1 | ram"; 
+			(0x02): result += "mbc1 | ram";
 			(0x03): result += "mbc1 | ram | battery";
-			(0x05): result += "mbc2"; 
+			(0x05): result += "mbc2";
 			(0x06): result += "mbc2 | battery";
-			(0x08): result += "no_mbc | ram"; 
+			(0x08): result += "no_mbc | ram";
 			(0x09): result += "no_mbc | ram | battery";
-			(0x0B): result += "mmm01"; 
+			(0x0B): result += "mmm01";
 			(0x0C): result += "mmm01 | ram";
-			(0x0D): result += "mmm01 | ram | battery"; 
+			(0x0D): result += "mmm01 | ram | battery";
 			(0x0F): result += "mbc3 | timer | battery";
-			(0x10): result += "mbc3 | timer | ram | battery"; 
+			(0x10): result += "mbc3 | timer | ram | battery";
 			(0x11): result += "mbc3";
-			(0x12): result += "mbc3 | ram"; 
+			(0x12): result += "mbc3 | ram";
 			(0x13): result += "mbc3 | ram | battery";
-			(0x19): result += "mbc5"; 
+			(0x19): result += "mbc5";
 			(0x1A): result += "mbc5 | ram";
-			(0x1B): result += "mbc5 | ram | battery"; 
+			(0x1B): result += "mbc5 | ram | battery";
 			(0x1C): result += "mbc5 | rumble";
-			(0x1D): result += "mbc5 | rumble | ram"; 
+			(0x1D): result += "mbc5 | rumble | ram";
 			(0x1E): result += "mbc5 | rumble | ram | battery";
-			(0x20): result += "mbc6"; 
+			(0x20): result += "mbc6";
 			(0x22): result += "mbc7 | sensor | rumble";
-			(0xFC): result += "camera"; 
+			(0xFC): result += "camera";
 			(0xFD): result += "tama5";
-			(0xFE): result += "huc3"; 
+			(0xFE): result += "huc3";
 			(0xFF): result += "huc1 | ram | battery";
 		}
 		if (uppercaseROMFeatures) result = std::string::to_upper(result);
-		return result + " )"; 
+		return result + " )";
 	};
-	
+
 	fn licensee_code(u8 code) {
 		match(code) {
 			(0x00): return "None";
@@ -199,7 +199,7 @@ namespace format {
 			(0xCA): return "Ultra";
 			(0xCB): return "Vap";
 			(0xCC): return "Use Corporation";
-			(0xCD): return "Meldac"; 
+			(0xCD): return "Meldac";
 			(0xD1): return "Sofel";
 			(0xD2): return "Quest";
 			(0xD3): return "Sigma Enterprises";
@@ -224,7 +224,7 @@ namespace format {
 		return "Unknown Licensee";
 	};
 
-	fn new_licensee_code(str a) {		
+	fn new_licensee_code(str a) {
 		if (std::mem::read_unsigned(0x14B, 1) != 0x33) return "See old licensee code";
 		match(a) {
 			("00"): return "None";
@@ -293,7 +293,7 @@ namespace format {
 	};
 
 	using CGB;
-	
+
 	fn null_cgb_flags(CGB flags) {
 		return "NO_CGB";
 	};

--- a/patterns/gguf.hexpat
+++ b/patterns/gguf.hexpat
@@ -85,7 +85,7 @@ struct gguf_string_t {
 struct gguf_metadata_value_t {
     gguf_metadata_value_type type;
     u64 length;
-    
+
     match(type) {
         (gguf_metadata_value_type::GGUF_METADATA_VALUE_TYPE_UINT8): u8 value[length];
         (gguf_metadata_value_type::GGUF_METADATA_VALUE_TYPE_INT8): s8 value[length];
@@ -117,7 +117,7 @@ struct gguf_metadata_value {
         (gguf_metadata_value_type::GGUF_METADATA_VALUE_TYPE_STRING): gguf_string_t value;
         (gguf_metadata_value_type::GGUF_METADATA_VALUE_TYPE_UINT64): u64 value;
         (gguf_metadata_value_type::GGUF_METADATA_VALUE_TYPE_FLOAT64): double value;
-        (gguf_metadata_value_type::GGUF_METADATA_VALUE_TYPE_ARRAY): gguf_metadata_value_t value;       
+        (gguf_metadata_value_type::GGUF_METADATA_VALUE_TYPE_ARRAY): gguf_metadata_value_t value;
     }
 };
 
@@ -132,7 +132,7 @@ struct gguf_metadata_kv_t {
     // The type of the value.
     // Must be one of the `gguf_metadata_value_type` values.
     // gguf_metadata_value_type value_type;
-    
+
     // The value.
     gguf_metadata_value value;
 };

--- a/patterns/gif.hexpat
+++ b/patterns/gif.hexpat
@@ -27,7 +27,7 @@ bitfield GCT_Flags {
     colorRes : 3 [[comment("Indicates the richness of the original pallet")]];
     enabled : 1;
 };
-    
+
 bitfield ImageDescriptorFlags {
     lctSize: 3;
     reserved: 2;
@@ -35,7 +35,7 @@ bitfield ImageDescriptorFlags {
     interlaceFlag: 1;
     lctEnable: 1;
 };
-    
+
 bitfield GCE_Flags {
     transparent : 1;
     userInput : 1;
@@ -109,7 +109,7 @@ struct PlainTextExtension {
     u8 textForegroundColorIndex;
     u8 textBackgroundColorIndex;
     DataSubBlocks plainTextData;
-    
+
 };
 
 struct GraphicControlExtension {
@@ -141,9 +141,9 @@ namespace format {
         if(value == 0x00) return "Do nothing";
         if(value == 0x01) return "Do not remove pixels";
         if(value == 0x02) return "Restore background pixels";
-        if(value == 0x03) return "Restore previous pixels"; 
+        if(value == 0x03) return "Restore previous pixels";
     };
-    
+
     fn extension_name(u8 label) {
         if(label == LABEL_GC) return "Graphical Control Extension";
         if(label == LABEL_COMMENT) return "Comment Extension";

--- a/patterns/gltf.hexpat
+++ b/patterns/gltf.hexpat
@@ -67,3 +67,4 @@ fn gltf_format(gltf_chunk_type_t x)
 gltf_magic_t magic @ 0x00;
 gltf_chunk_t chunks[while(!std::mem::eof())] @ $;
 
+std::assert_warn(std::mem::size() == magic.length, "file size mismatch");

--- a/patterns/gltf.hexpat
+++ b/patterns/gltf.hexpat
@@ -1,6 +1,6 @@
 /**
  * @file <gltf.hexpat> ImHex Pattern for glTF binary files.
- * 
+ *
  * Copyright (c) 2023 H. Utku Maden <utkumaden@hotmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -59,7 +59,7 @@ fn gltf_format(gltf_chunk_type_t x)
 {
          if (x == gltf_chunk_type_t::JSON) return "JSON";
     else if (x == gltf_chunk_type_t::BIN) return "BIN";
-    
+
     return "";
 };
 

--- a/patterns/gltf.hexpat
+++ b/patterns/gltf.hexpat
@@ -28,12 +28,13 @@
 
 import std.mem;
 import std.io;
+import type.magic;
 
 /**
  * @brief The glTF magic section.
  */
 struct gltf_magic_t {
-    char magic[4];  /**< The magic value. Must be "glTF" */
+    type::Magic<"glTF"> magic;  /**< The magic value. Must be "glTF" */
     u32 version;    /**< The version. Must be 2 for glTF 2.0. */
     u32 length;     /**< Length of the file in bytes, including magic section. */
 };
@@ -66,5 +67,3 @@ fn gltf_format(gltf_chunk_type_t x)
 gltf_magic_t magic @ 0x00;
 gltf_chunk_t chunks[while(!std::mem::eof())] @ $;
 
-if (magic.magic != "glTF")
-    std::error("This file might not be a glTF file, expected \"glTF\", got %s", magic.magic);

--- a/patterns/gzip.hexpat
+++ b/patterns/gzip.hexpat
@@ -55,26 +55,26 @@ struct GZip {
     type::time32_t modificationTime;
     ExtraFlags extraFlags;
     OperatingSystemID operatingSystemId;
-    
+
     if (flags.FEXTRA) {
         u16 extraLength;
         u8 extraField[extraLength];
     }
-    
+
     if (flags.FNAME) {
         char originalFileName[];
     }
-    
+
     if (flags.FCOMMENT) {
         char comment[];
     }
-    
+
     if (flags.FHCRC) {
         u16 crc16;
     }
-    
+
     u8 data[while($ < std::mem::size() - 8)] [[sealed]];
-    
+
     u32 crc32;
     type::Size<u32> isize;
 };

--- a/patterns/hinf_luas.hexpat
+++ b/patterns/hinf_luas.hexpat
@@ -26,7 +26,7 @@ enum lua_endian : u8 {
     little_endian = 1,
     big_endian = 0,
 };
-    
+
 enum lua_numbertype : u8 {
     _float = 0,
     _int32 = 1,
@@ -136,7 +136,7 @@ enum HksOpCode : s8 {
         GETSLOT_D,
         GETGLOBAL_MEM,
     };
-    
+
 enum HksType : u8
     {
         TNIL,
@@ -212,10 +212,10 @@ struct LuaConstant {
     }
     else if (type == HksType::TLIGHTUSERDATA) {
         s64 userdata;
-    } 
+    }
     else {
         s64 data;
-    } 
+    }
 };
 
 struct HksLocal {
@@ -226,7 +226,7 @@ struct HksLocal {
 
 
 struct LuaFunction {
-   
+
     s32 upvaluecount;
     s32 paramcount;
     s8 isVarArg;
@@ -422,7 +422,7 @@ struct LuaScriptTagDefinition {
    LuaHeader lua_header;
    try {
     char pad[14];
-    LuaReferencedTagContainer referencedTags[referencedTags_count.count]; 
+    LuaReferencedTagContainer referencedTags[referencedTags_count.count];
    } catch {
     std::print("This file does not support referenced Tags.");
    }

--- a/patterns/hinf_luas.hexpat
+++ b/patterns/hinf_luas.hexpat
@@ -238,7 +238,7 @@ struct LuaFunction {
     }
     LuaInstruction instructions[instruction_count];
     s32 constantCount;
-    LuaConstant constants[constantCount];;
+    LuaConstant constants[constantCount];
     s32 HasDebugInfo;
     if (HasDebugInfo != 0) {
         u32 LineCount;

--- a/patterns/hinf_module.hexpat
+++ b/patterns/hinf_module.hexpat
@@ -5,7 +5,7 @@
 
 import std.string;
 
-struct ModuleHeader 
+struct ModuleHeader
 {
     char magic[4];
     s32 version;
@@ -68,7 +68,7 @@ struct Module
     ModuleFile files[module_header.fileCount];
     $ = $ + 8;
     s32 resources[module_header.resourceCount];
-    ModuleBlock blocks[module_header.blockCount]; 
+    ModuleBlock blocks[module_header.blockCount];
     padding[while($[$] == 0)];
     std::print("Compressed Tag Data starts at: {}", $);
 };

--- a/patterns/ico.hexpat
+++ b/patterns/ico.hexpat
@@ -31,7 +31,7 @@ struct ICONDIRENTRY {
 	u8 width, height;
 	u8 num_colors;
 	u8 reserved [[hidden]];
-	
+
 	if (header.type == ImageType::Icon) {
 		u16 color_planes;
 		u16 bits_per_pixel;
@@ -39,7 +39,7 @@ struct ICONDIRENTRY {
 		u16 horizontal_hotspot_coordinate;
 		u16 vertical_hotspot_coordinate;
 	}
-	
+
 	u32 image_data_size;
 	ImageData *image_data : u32;
 };

--- a/patterns/id3.hexpat
+++ b/patterns/id3.hexpat
@@ -40,7 +40,7 @@ namespace v2 {
         u8 major;
         u8 revision;
     };
-    
+
     bitfield TagHeaderFlags {
         unsynchronized : 1;
         extended       : 1;
@@ -48,14 +48,14 @@ namespace v2 {
         footer         : 1;
         padding        : 4;
     };
-    
+
     struct TagHeader {
         char           identifier[3];
         TagVersion     version;
         TagHeaderFlags flags;
         SyncSafeInt    size;
     } [[static]];
-    
+
     bitfield ExtendedFlag {
         padding      : 1;
         update       : 1;
@@ -70,14 +70,14 @@ namespace v2 {
         ExtendedFlag flags[nflagbytes];
         u8           data[size];
     };
-    
+
     struct TagFooter {
         char           identifier[3];
         TagVersion     version;
         TagHeaderFlags flags;
         SyncSafeInt    size;
     } [[static]];
-    
+
     bitfield FrameFlags {
         padding               : 1;
         tagalterpreservation  : 1;
@@ -123,7 +123,7 @@ namespace v2 {
     };
 
     }
-    
+
     struct Frame {
         FrameId     id;
         SyncSafeInt size;

--- a/patterns/intel_hex.hexpat
+++ b/patterns/intel_hex.hexpat
@@ -1,9 +1,9 @@
 #pragma description Intel hex
 
-/* If you have no delimiters between data records then remove 
+/* If you have no delimiters between data records then remove
  * the null_bytes field in the data_packet struct.
  * Set the array at the bottom to the highest index + 1 in the Pattern Data view
- * NOTE: these were ascii hex values for me, so use the calculator tool to convert 
+ * NOTE: these were ascii hex values for me, so use the calculator tool to convert
  * values
 */
 #pragma endian big
@@ -29,25 +29,25 @@ struct data_packet {
 	Bytes byte_count [[color("00A9CBB7")]];
 	u32 address [[color("00F7FF58")]];
 	FileType recordType [[color("00FF934F")]];
-	
+
 	// both not A
 	if (byte_count.HOB < 65 && byte_count.LOB < 65) {
-		u16 data[((byte_count.HOB - 48) * 16) 
-			+ (byte_count.LOB - 48)] [[color("0095B46A")]]; 
+		u16 data[((byte_count.HOB - 48) * 16)
+			+ (byte_count.LOB - 48)] [[color("0095B46A")]];
 	// HOB is A but LOB is not
 	} else if (byte_count.HOB >= 65 && byte_count.LOB < 65) {
-		u16 data[((byte_count.HOB - 55) * 16) 
-			+ (byte_count.LOB - 48)] [[color("0095B46A")]]; 
+		u16 data[((byte_count.HOB - 55) * 16)
+			+ (byte_count.LOB - 48)] [[color("0095B46A")]];
 	// LOB is A but HOB is not
 	} else if (byte_count.HOB < 65 && byte_count.LOB >= 65) {
-		u16 data[((byte_count.HOB - 48) * 16) 
+		u16 data[((byte_count.HOB - 48) * 16)
 			+ (byte_count.LOB - 55)] [[color("0095B46A")]];
 	// both are A
 	} else {
-		u16 data[((byte_count.HOB - 55) * 16) 
-			+ (byte_count.LOB - 55)] [[color("0095B46A")]]; 
+		u16 data[((byte_count.HOB - 55) * 16)
+			+ (byte_count.LOB - 55)] [[color("0095B46A")]];
 	}
-	
+
 	u16 checksum [[color("0045F0DF")]];
 	u8 line_ending_1 [[color("005E565A")]];
 	if (line_ending_1 == '\r')

--- a/patterns/ip.hexpat
+++ b/patterns/ip.hexpat
@@ -89,9 +89,9 @@ namespace ip {
 		OSPF 	= 89,
 		SCTP 	= 132
 	};
-	
+
 	namespace udp {
-	
+
 		struct Packet {
 			u16 source_port;
 			u16 destination_port;
@@ -100,11 +100,11 @@ namespace ip {
 			u16 checksum;
 			u8 data[length - 8];
 		};
-	
+
 	}
-	
+
 	namespace tcp {
-	
+
 		bitfield Flags {
 			data_offset : 4;
 			padding : 3;
@@ -118,7 +118,7 @@ namespace ip {
 			syn : 1;
 			fin : 1;
 		};
-	
+
 		struct Packet {
 			u16 source_port;
 			u16 destination_port;
@@ -128,15 +128,15 @@ namespace ip {
 			u16 window_size;
 			u16 checksum;
 			u16 urgent_pointer;
-			
+
 			if (flags.data_offset > 5)
 				u8 options[(flags.data_offset - 5) * sizeof(u32)];
-				
+
 			u8 data[parent.parent.header.total_length - parent.parent.header.ihl * 4 - flags.data_offset * 4];
 		};
-	
+
 	}
-	
+
 	struct Payload {
 		if (parent.protocol == ip::Protocol::UDP)
 			udp::Packet packet [[inline]];
@@ -153,7 +153,7 @@ namespace ipv4 {
 	struct Address {
 		u8 octets[4];
 	} [[format("ipv4::address_formatter")]];
-	
+
 	fn address_formatter(Address addr) {
 		return std::format("{0}.{1}.{2}.{3}",
 			addr.octets[0],
@@ -168,15 +168,15 @@ namespace ipv4 {
 		tos 			: 8;
 		total_length 	: 16;
 	};
-	
+
 	bitfield Flags {
 		reserved 		: 1;
 		df 				: 1;
 		mf 				: 1;
 		fragment_offset : 13;
 	};
-		
-	
+
+
 	struct Packet {
 		Header header [[inline]];
 		u16 identification;
@@ -184,16 +184,16 @@ namespace ipv4 {
 		u8 time_to_live;
 		ip::Protocol protocol;
 		u16 header_checksum;
-		
+
 		Address source_ip_address;
 		Address destination_ip_address;
-		
+
 		if (header.ihl > 5)
 			u8 options[(header.ihl - 5) * sizeof(u32)];
-			
+
 		ip::Payload payload;
 	};
-	
+
 }
 
 
@@ -202,7 +202,7 @@ namespace ipv6 {
 	struct Address {
 		u16 segments[8];
 	} [[format("ipv6::address_formatter")]];
-	
+
 	fn address_formatter(Address addr) {
 		return std::format("{0:04X}:{1:04X}:{2:04X}:{3:04X}:{4:04X}:{5:04X}:{6:04X}:{7:04X}",
 			addr.segments[0],
@@ -221,16 +221,16 @@ namespace ipv6 {
 		ecn 		: 2;
 		flow_label 	: 20;
 	};
-	
+
 	struct Packet {
 		Header header [[inline]];
 		u16 payload_length;
 		ip::Protocol next_header;
 		u8 hop_limit;
-		
+
 		Address source_address;
 		Address destination_address;
-		
+
 		ip::Payload payload;
 	};
 
@@ -254,18 +254,18 @@ bitfield TCI {
 struct EthernetIIFrame {
 	MAC destination_address;
 	MAC source_address;
-	
+
 	u16 possible_tpid [[no_unique_address, hidden]];
 	if (possible_tpid == EtherType::VLANTaggedFrame) {
 		u16 tpid;
 		TCI tci [[inline]];
 	}
-	
+
 	EtherType type;
-	
+
 	Payload payload;
 	std::assert(sizeof(payload) >= 40 && sizeof(payload) <= 1500, std::format("Payload size out of range: {}", sizeof(payload)));
-	
+
 	u32 frame_check_sequence;
 };
 

--- a/patterns/java_class.hexpat
+++ b/patterns/java_class.hexpat
@@ -26,7 +26,7 @@ bool applyPadding = false;
 
 struct cp_info {
     bool isTop = false;
-    if(applyPadding) { 
+    if(applyPadding) {
         isTop = true;
         applyPadding = false;
     }
@@ -92,7 +92,7 @@ struct cp_info {
             }
         }
     }
-} [[format("fmt::const_name")]];    
+} [[format("fmt::const_name")]];
 
 namespace fmt {
     fn const_name(auto tag) {
@@ -115,7 +115,7 @@ namespace fmt {
             (_): return "Unknown";
         }
     };
-    
+
     fn const_ref(u2 index) {
         cp_info info = file.constant_pool[index-1];
         match(info.tag) {
@@ -138,7 +138,7 @@ namespace fmt {
             (_): return std::format("{:d} [Unknown]", index);
         }
     };
-    
+
     fn const_ref_top(u2 index) {
         cp_info info = file.constant_pool[index-1];
         match(info.tag) {
@@ -357,7 +357,7 @@ namespace fmt {
             (_): return std::format("{:d} [Unknown]", value);
         }
     };
-    
+
     fn atype_fmt(auto atype) {
         match(atype) {
             (4): return "T_BOOLEAN";
@@ -370,11 +370,11 @@ namespace fmt {
             (11): return "T_LONG";
         }
     };
-    
+
     fn instruction_code_fmt(ref auto code) {
         return fmt::byte_code_fmt(code.mnemonic);
     };
-    
+
     fn attribute(auto info) {
         return file.constant_pool[info.attribute_name_index-1].bytes;
     };
@@ -521,7 +521,7 @@ bitfield access_flags_module {
     padding          : 1;    // 0x4000
     ACC_MANDATED     : 1;    // 0x8000
 } [[bitfield_order(BitfieldOrder::LeastToMostSignificant, 16)]];
-       
+
 using attribute_code;
 
 struct attribute_constant_value {

--- a/patterns/jpeg.hexpat
+++ b/patterns/jpeg.hexpat
@@ -107,7 +107,7 @@ fn sof0_component_read(SOF0Component c) {
 fn get_eoi_marker_position() {
     u32 pos = std::mem::find_sequence_in_range(0, $, std::mem::size(), 0xFF, 0xD9);
     return pos;
-    
+
 };
 
 struct SOF0 {
@@ -138,9 +138,9 @@ struct Segment {
     } else {
         type::Magic<"\xff"> magic;
         Marker marker;
-        
+
         if (marker == Marker::SOI || marker == Marker::EOI) {
-            
+
         } else {
             u16 length;
             if (marker == Marker::APP0) {

--- a/patterns/jpeg.hexpat
+++ b/patterns/jpeg.hexpat
@@ -42,7 +42,7 @@ enum Marker : u8 {
     APP14   = 0xEE,
     APP15   = 0xEF,
     COM     = 0xFE,
-    UNKNOWN = 0X00
+    UNKNOWN = 0x00
 };
 
 enum DensityUnit : u8 {

--- a/patterns/lcesave.hexpat
+++ b/patterns/lcesave.hexpat
@@ -38,7 +38,7 @@ fn getFileType(str filename) {
                 return "Level File";
             else
                 return "Unknown DAT";
-      
+
         (_): return "File";
     }
 };
@@ -79,14 +79,14 @@ struct LCESave {
     u8 zlibMagic[2] @ 0x08 [[hidden]];
     // check if header matches
     if (zlibMagic[0] == 0x78 && zlibMagic[1] == 0x9C)
-        CompressedSave compSave @ 0x00;    
-    
+        CompressedSave compSave @ 0x00;
+
     // if not we will have continued.
     le u16 endianCheck @ 0x0A [[hidden]];
     // check if version is bigger than 14
     if (endianCheck > 14)
         std::core::set_endian(std::mem::Endian::Big);
-        
+
     // rest of the processing
     LCEHeader header [[name("Header")]];
     if (header.curVersion > 1)

--- a/patterns/lnk.hexpat
+++ b/patterns/lnk.hexpat
@@ -104,7 +104,7 @@ enum Keys : u8 {
     KEY_X       = 0x58,
     KEY_Y       = 0x59,
     KEY_Z       = 0x5A,
-    
+
     VK_F1       = 0x70,
     VK_F2       = 0x71,
     VK_F3       = 0x72,
@@ -161,12 +161,12 @@ struct ShellLinkHeader {
     HotKeyFlags HotKey;
     padding[2];
     padding[4];
-    padding[4];	
+    padding[4];
 };
 
 struct ItemID {
     type::Size16 ItemIDSize;
-    
+
     if (ItemIDSize == 0x00)
         break;
     else
@@ -264,15 +264,15 @@ struct CommonNetworkRelativeLink {
     u32 NetNameOffset;
     u32 DeviceNameOffset;
     NetworkProviderType NetworkProviderType;
-    
+
     if (NetNameOffset > 0x14) {
         u32 NetNameOffsetUnicode;
         u32 DeviceNameOffsetUnicode;
     }
-    
+
     char NetName[];
     char DeviceName[];
-        
+
     if (NetNameOffset > 0x14) {
         char16 NetNameUnicode[];
         char16 DeviceNameUnicode[];
@@ -287,22 +287,22 @@ struct LinkInfo {
     u32 LocalBasePathOffset;
     u32 CommonNetworkRelativeLinkOffset;
     u32 CommonPathSuffixOffset;
-    
+
     if (LinkInfoHeaderSize >= 0x24) {
         u32 LocalBasePathOffsetUnicode;
         u32 CommonPathSuffixOffsetUnicode;
     }
-    
+
     if (LinkInfoFlags.VolumeIDAndLocalBasePath) {
         VolumeID VolumeID;
         char LocalBasePath[];
-    }	
-    
+    }
+
     if (LinkInfoFlags.CommonNetworkRelativeLinkAndPathSuffix)
         CommonNetworkRelativeLink CommonNetworkRelativeLink;
-        
+
     char CommonPathSuffix[];
-    
+
     if (LinkInfoHeaderSize >= 0x24) {
         if (LinkInfoFlags.VolumeIDAndLocalBasePath)
             char16 LocalBasePathUnicode[];
@@ -333,12 +333,12 @@ bitfield FillAttributes {
     FOREGROUND_GREEN        : 1;
     FOREGROUND_RED          : 1;
     FOREGROUND_INTENSITY    : 1;
-    
+
     BACKGROUND_BLUE         : 1;
     BACKGROUND_GREEN        : 1;
     BACKGROUND_RED          : 1;
     BACKGROUND_INTENSITY    : 1;
-    
+
     padding                 : 8;
 };
 
@@ -417,12 +417,12 @@ struct VistaAndAboveIDListDataBlock {
 
 struct ExtraDataBlock {
     type::Size32 BlockSize;
-    
+
     if (BlockSize < 0x04)
         break;
     else {
         u32 BlockSignature;
-    
+
         if (BlockSignature == 0xA000'0002)
             ConsoleDataBlock CONSOLE_PROPS;
         else if (BlockSignature == 0xA000'0004)

--- a/patterns/lua51.hexpat
+++ b/patterns/lua51.hexpat
@@ -9,11 +9,11 @@ namespace impl {
         }
         return std::format("\"{}\"", string.data);
     };
-    
+
     fn format_Constant(auto constant) {
        return constant.data;
     };
-    
+
     fn format_Version(auto ver) {
        return std::format("Ver. {}.{}", ver.major, ver.minor);
     };

--- a/patterns/lua52.hexpat
+++ b/patterns/lua52.hexpat
@@ -10,11 +10,11 @@ namespace impl {
         }
         return std::format("\"{}\"", string.data);
     };
-    
+
     fn format_Constant(auto constant) {
        return constant.data;
     };
-    
+
     fn format_Version(auto ver) {
        return std::format("Ver. {}.{}", ver.major, ver.minor);
     };

--- a/patterns/lua53.hexpat
+++ b/patterns/lua53.hexpat
@@ -10,11 +10,11 @@ namespace impl {
         }
         return std::format("\"{}\"", string.data);
     };
-    
+
     fn format_Constant(auto constant) {
        return constant.data;
     };
-    
+
     fn format_Version(auto ver) {
        return std::format("Ver. {}.{}", ver.major, ver.minor);
     };

--- a/patterns/lua54.hexpat
+++ b/patterns/lua54.hexpat
@@ -15,7 +15,7 @@ namespace impl {
         res |= array[sizeof(array)-1] & 0x7f;
         return res;
     };
-    
+
     fn format_Size(auto leb128) {
         u128 res = impl::transform_Size_array(leb128.array);
         return std::format("{} ({:#x})", res, res);
@@ -24,18 +24,18 @@ namespace impl {
     fn transform_Size(auto leb128) {
         return impl::transform_Size_array(leb128.array);
     };
-    
+
     fn format_LuaString(auto string) {
        if (string.size == 0) {
            return "None";
         }
         return std::format("\"{}\"", string.data);
     };
-    
+
     fn format_Constant(auto constant) {
        return constant.data;
     };
-    
+
     fn format_Version(auto ver) {
        return std::format("Ver. {}.{}", ver.major, ver.minor);
     };
@@ -47,7 +47,7 @@ using LuaFunction;
 struct Size {
         u8 array[while(addressof(this) == $ || ((addressof(this)-$ < 9) && (std::mem::read_unsigned($-1, 1) & 0x80 == 0)))] [[hidden]];
 } [[sealed, format("impl::format_Size"), transform("impl::transform_Size")]];
-    
+
 
 bitfield Version {
     minor : 4;

--- a/patterns/lznt1.hexpat
+++ b/patterns/lznt1.hexpat
@@ -104,7 +104,7 @@ struct Tuple {
         u128 destinationPos = std::mem::get_section_size(decompressedSection);
         u128 destinationBackrefPos = destinationPos + ct.actualDisplacement;
         u128 maxNonOverlap = destinationPos - destinationBackrefPos;
-        
+
         if (ct.actualLength <= maxNonOverlap) { // Not overlapping
             std::mem::copy_section_to_section(decompressedSection,
                                               destinationBackrefPos,

--- a/patterns/macho.hexpat
+++ b/patterns/macho.hexpat
@@ -230,7 +230,7 @@ struct Header {
     else if (cpuType == CpuType::BS32032 || cpuType == CpuType::BS32332 || cpuType == CpuType::NS32532) SubCpuType32XXX subCpuType;
     else if (cpuType == CpuType::I386 || cpuType == CpuType::X86_64) SubCpuTypeI386 subCpuType;
     else if (cpuType == CpuType::MIPS) SubCpuTypeMips subCpuType;
-    else if (cpuType == CpuType::HPPA) SubCpuTypeHPPA subCpuType;    
+    else if (cpuType == CpuType::HPPA) SubCpuTypeHPPA subCpuType;
     else if (cpuType == CpuType::ARM) SubCpuTypeARM subCpuType;
     else if (cpuType == CpuType::MC88000) SubCpuTypeMC88000 subCpuType;
     else if (cpuType == CpuType::MC98000) SubCpuTypeMC98000 subCpuType;
@@ -244,7 +244,7 @@ struct Header {
     u32 numCommands;
     type::Size<u32> sizeOfCommands;
     Flags flags;
-    
+
     if (magic == Magic::_64BitMagic) padding[sizeof(u32)];
 };
 
@@ -312,7 +312,7 @@ struct Section {
     u32 numRelocs;
     u32 flags;
     padding[8];
-    
+
     if (offset > 0)
         u8 data[size] @ offset [[sealed]];
 };
@@ -327,9 +327,9 @@ struct CommandSegment {
     u32 initProtection;
     u32 numSections;
     u32 flags;
-    
+
     Section sections[numSections];
-    
+
     if (fileOffset > 0)
         u8 data[fileSize] @ fileOffset [[sealed]];
 };
@@ -345,7 +345,7 @@ struct Section64 {
     u32 numRelocs;
     u32 flags;
     padding[12];
-    
+
     if (offset > 0)
         u8 data[size] @ offset [[sealed]];
 };
@@ -360,9 +360,9 @@ struct CommandSegment64 {
     u32 initProtection;
     u32 numSections;
     u32 flags;
-    
+
     Section64 sections[numSections];
-    
+
     if (fileOffset > 0)
         u8 data[fileSize] @ fileOffset [[sealed]];
 };
@@ -370,7 +370,7 @@ struct CommandSegment64 {
 struct LoadCommand {
     Command command;
     type::Size<u32> commandSize;
-    
+
     if (command == Command::UUID)
         CommandUUID data;
     else if (command == Command::Segment)

--- a/patterns/max_v104.hexpat
+++ b/patterns/max_v104.hexpat
@@ -288,7 +288,7 @@ struct UnitValues
 struct Complex
 {
   u16 object_index;
-  
+
   if(CheckObjectId(object_index, true) == true)
   {
     u16 class_type;
@@ -461,11 +461,11 @@ struct PathStep
 struct Path
 {
   u16 object_index;
-  
+
   if(CheckObjectId(object_index, true) == true)
   {
     u16 class_type;
-    
+
     // Air path
     if (class_type == 1)
     {
@@ -513,12 +513,12 @@ struct UnitInfo
   {
     u16 class_type;
     UnitType unit_type;
-    
+
     if (unit_type == UnitType::UNIT_TYPE_DEAD_WALDO)
     {
       std::print("Found Waldo!");
     }
-    
+
     u16 hash_id;
     UnitFlags flags;
     Point pixel_position;
@@ -678,19 +678,19 @@ struct AiPlayer
   TeamIndex16 target_team;
   AiMapList map_list;
   u16 has_info_map;
-  
+
   if (has_info_map)
   {
   	u8 info_map[12544];
   }
-  
+
   u16 has_mine_map;
-  
+
   if (has_mine_map)
   {
     u8 mine_map[12544];
   }
-  
+
   Point target_location;
 };
 
@@ -722,7 +722,7 @@ fn CheckObjectId(u16 index, bool caller)
   	last_object_index = index;
   	result = true;
   }
-  
+
   return result;
 };
 
@@ -803,7 +803,7 @@ struct SaveFile
   MessageLogList message_log_green;
   MessageLogList message_log_blue;
   MessageLogList message_log_gray;
-  
+
   if (team_type_red == TeamType::Computer)
   {
     AiPlayer ai_player_red;

--- a/patterns/minidump.hexpat
+++ b/patterns/minidump.hexpat
@@ -263,7 +263,7 @@ struct MINIDUMP_UNLOADED_MODULE_LIST {
 
     if (SizeOfHeader > 12)
         padding[header.SizeOfHeader - 12];
-        
+
     MINIDUMP_UNLOADED_MODULE Modules[NumberOfEntries];
 };
 
@@ -303,7 +303,7 @@ struct MINIDUMP_MEMORY_INFO_LIST {
 
     if (SizeOfHeader > 16)
         padding[SizeOfHeader - 16];
-        
+
     MINIDUMP_MEMORY_INFO Info[NumberOfEntries];
 };
 
@@ -327,7 +327,7 @@ struct MINIDUMP_THREAD_INFO_LIST {
 
     if (SizeOfHeader > 12)
         padding[SizeOfHeader - 12];
-        
+
     MINIDUMP_THREAD_INFO Info[NumberOfEntries];
 };
 

--- a/patterns/mp4.hexpat
+++ b/patterns/mp4.hexpat
@@ -56,7 +56,7 @@ struct BaseBox {
         u64 largeSize;
         boxSize = largeSize;
         endOffset = startOffset + boxSize;
-    } else if (this.size == 0) { 
+    } else if (this.size == 0) {
         boxSize = std::mem::size() - startOffset;
         endOffset = std::mem::size();
     } else {

--- a/patterns/msgpack.hexpat
+++ b/patterns/msgpack.hexpat
@@ -51,7 +51,7 @@ struct MapEntry {
 
 struct MessagePack {
 	Type type;
-	
+
 	if (u8(type) <= 0x7F) {
 		$ -= 1;
 		u8 value;

--- a/patterns/nacp.hexpat
+++ b/patterns/nacp.hexpat
@@ -145,7 +145,7 @@ fn main() {
 	std::print("Application Name:       {}", nacp.american_english_title.name);
 	std::print("Application Publisher:  {}", nacp.american_english_title.publisher);
 	std::print("Application Version:    {}", nacp.display_version);
-	
+
 	if (nacp.device_save_data_size_max > 0)
 		std::print("This application has a device save file!");
 };

--- a/patterns/nbt.hexpat
+++ b/patterns/nbt.hexpat
@@ -46,7 +46,7 @@ struct Value {
         Tag tag;
         s32 listLength;
         Value values[listLength] [[static]];
-    } else if (parent.tag == Tag::Compound) {       
+    } else if (parent.tag == Tag::Compound) {
         Element values[while(true)];
     } else if (parent.tag == Tag::IntArray){
         s32 arrayLength;
@@ -67,7 +67,7 @@ struct Element {
 
         u16 nameLength;
         char name[nameLength];
-            
+
         Value value;
     }
 };

--- a/patterns/ne.hexpat
+++ b/patterns/ne.hexpat
@@ -1,4 +1,4 @@
-#pragma description Microsoft DOS NE executable 
+#pragma description Microsoft DOS NE executable
 
 import std.mem;
 
@@ -83,7 +83,7 @@ enum DGroupType : u8 {
 
 fn formatDGroupType(u8 value) {
 	DGroupType dgroup = value;
-	
+
 	return dgroup;
 };
 
@@ -96,7 +96,7 @@ enum AppType : u8 {
 
 fn formatAppType(u8 value) {
 	AppType app = value;
-	
+
 	return app;
 };
 
@@ -138,7 +138,7 @@ bitfield OS2EXEFlags {
 	gangloadArea : 1;
 };
 
-struct NEHeader { 
+struct NEHeader {
     char signature[2];
     u8 majorLinkerVersion;
     u8 minorLinkerVersion;

--- a/patterns/notepad-cache.hexpat
+++ b/patterns/notepad-cache.hexpat
@@ -1,7 +1,7 @@
 #pragma author sethhall
 #pragma description Windows Notepad Cache Files
 
-// This was written based on the following blog post: 
+// This was written based on the following blog post:
 //    https://u0041.co/posts/articals/exploring-windows-artifacts-notepad-files/
 
 import type.leb128;

--- a/patterns/ntag.hexpat
+++ b/patterns/ntag.hexpat
@@ -41,22 +41,22 @@ enum TNFType : u8 {
 struct NDEF {
 	NDEFFlags flags;
 	u8 typeLength;
-	
+
 	if (flags.SR)
 		u8 payloadLength;
 	else
 		u32 payloadLength;
-		
+
 	if (flags.IL)
 		u8 idLength;
-		
+
 	char type[typeLength];
-	
+
 	if (flags.IL)
 		u8 id[idLength];
-	
+
 	u8 payload[payloadLength];
-		
+
 	if (flags.ME)
 		break;
 };
@@ -102,7 +102,7 @@ struct TLV {
 		// Empty
 	} else {
 		Length length;
-		
+
 		if (length > 0) {
 			if (tag == Tag::LockControl) {
 				LockControl lockControl;
@@ -154,25 +154,25 @@ fn validate_ntag_checksum(ManufacturerData mdata) {
     0x88 is the CT/cascade digit.
     This is XOR'd with the first 3 bytes of the serial to calculate BCC0.
     */
-    
-    u8 bcc0 = 0x88 ^ 
+
+    u8 bcc0 = 0x88 ^
     mdata.serial1[0] ^
     mdata.serial1[1] ^
     mdata.serial1[2];
-    
+
     if (bcc0 == mdata.checkByte0) {
         std::print("NTAG BCC0 checksum OK. Value: {}", bcc0);
     } else {
         std::warning(std::format("NTAG BCC0 checksum failed! Value: {}", bcc0));
     }
-    
+
     // BCC1 is the XOR of the last 4 serial bytes.
-    
+
     u8 bcc1 = mdata.serial2[0] ^
     mdata.serial2[1] ^
     mdata.serial2[2] ^
     mdata.serial2[3];
-    
+
     if (bcc1 == mdata.checkByte1) {
         std::print("NTAG BCC1 checksum OK. Value: {}", bcc1);
     } else {

--- a/patterns/pck.hexpat
+++ b/patterns/pck.hexpat
@@ -23,12 +23,12 @@ namespace format
     {
         return pck.lut.table[index].value;
     };
-    
+
     fn property(ref auto p)
     {
         return std::format("{}: {}", format::look_up_str(p.key), p.value);
     };
-    
+
     fn assets(ref auto assets)
     {
         return std::format("Assets: {}", assets.count);
@@ -38,12 +38,12 @@ namespace format
     {
         return std::format("count: {}", p.propertyCount);
     };
-    
+
     fn string(ref auto string)
     {
         return std::string::to_string(string.value);
     };
-    
+
     fn asset_entry(ref auto e)
     {
         return std::string::to_string(e.type);
@@ -96,22 +96,22 @@ enum AssetType : s32
     //! "0" file
     InfoFile = 4,
     //! (x16|x32|x64)Info.pck
-    TexturePackInfoFile = 5,    
+    TexturePackInfoFile = 5,
     //! languages.loc/localisation.loc
-    LocalisationFile = 6,    
-    //! GameRules.grf    
-    GameRulesFile = 7,    
-    //! audio.pck    
-    AudioFile = 8,    
-    //! colours.col    
-    ColourTableFile = 9,    
-    //! GameRules.grh    
-    GameRulesHeader = 10,    
-    //! Skins.pck    
-    SkinDataFile = 11,    
-    //! models.bin    
-	ModelsFile = 12,    
-    //! behaviours.bin 
+    LocalisationFile = 6,
+    //! GameRules.grf
+    GameRulesFile = 7,
+    //! audio.pck
+    AudioFile = 8,
+    //! colours.col
+    ColourTableFile = 9,
+    //! GameRules.grh
+    GameRulesHeader = 10,
+    //! Skins.pck
+    SkinDataFile = 11,
+    //! models.bin
+	ModelsFile = 12,
+    //! behaviours.bin
     BehavioursFile = 13,
     //! entityMaterials.bin
     MaterialFile = 14,
@@ -166,7 +166,7 @@ struct Assets
 } [[format("format::assets"), transform_entities("transform::assets")]];
 
 struct Pck
-{   
+{
     s32 version;
     if (version >> 24 & 0xff != 0)
     {

--- a/patterns/pe.hexpat
+++ b/patterns/pe.hexpat
@@ -520,7 +520,7 @@ struct Bitmap {
 		Colors rgbq[bmh.clrUsed*((1 << bmh.bitCount)*!bmh.clrUsed)];
 		imageDataSize = imageDataSize - sizeof(rgbq);
 	}
-	
+
 	u8 imageData[imageDataSize-sizeof(bmh)];
 };
 
@@ -1041,7 +1041,7 @@ struct LineNumber {
 
 bool dataDirectoryInSection[coffHeader.optionalHeader.numberOfRVAsAndSizes];
 
-fn checkForDataDirectory() { 
+fn checkForDataDirectory() {
 	for (u32 i = 0, i < coffHeader.optionalHeader.numberOfRVAsAndSizes, i += 1)
 		if (coffHeader.optionalHeader.directories[i].rva - relativeVirtualDifference() < sectionsTable[currentSectionIndex].ptrRawData+sectionsTable[currentSectionIndex].sizeOfRawData
 		 && coffHeader.optionalHeader.directories[i].rva - relativeVirtualDifference() >= $)

--- a/patterns/pfs0.hexpat
+++ b/patterns/pfs0.hexpat
@@ -22,7 +22,7 @@ struct Header {
     u32 numFiles;
     type::Size<u32> stringTableSize;
     padding[4];
-    
+
     FileEntry fileEntryTable[numFiles];
     String strings[numFiles];
 };
@@ -33,8 +33,8 @@ struct File {
 };
 
 struct PFS0 {
-    Header header; 
-    
+    Header header;
+
     File files[header.numFiles];
 };
 

--- a/patterns/pif.hexpat
+++ b/patterns/pif.hexpat
@@ -44,7 +44,7 @@ struct PIFInfoHeader {
 struct PIF {
 	PIFFileHeader PIF_FileHeader;
 	PIFInfoHeader PIF_ImageHeader;
-	
+
 	if (PIF_ImageHeader.ImageType == imageType_t::IND24)
 	{
 		u24 ColorTable[PIF_ImageHeader.ColorTableSize/3];
@@ -57,7 +57,7 @@ struct PIF {
 	{
 		u8 ColorTable[PIF_ImageHeader.ColorTableSize];
 	}
-	
+
 	if ((PIF_ImageHeader.ImageType == imageType_t::RGB888) ||
 		(PIF_ImageHeader.ImageType == imageType_t::IND24))
 	{

--- a/patterns/prodinfo.hexpat
+++ b/patterns/prodinfo.hexpat
@@ -1,5 +1,5 @@
 #pragma author WerWolv
-#pragma description Nintendo Switch PRODINFO 
+#pragma description Nintendo Switch PRODINFO
 
 enum Model : u16 {
 	NX = 1
@@ -42,15 +42,15 @@ struct PRODINFO {
 	u32 BodySize;
 	Model Model;
 	u16 UpdateCount;
-	
+
 	padding[0x10];
-	
+
 	u8 BodyHash[0x20];
 	char ConfigurationId1[0x1E];
-	
+
 	padding[0x02];
 	padding[0x20];
-	
+
 	u32 WlanCountryCodesNum;
 	u32 WlanCountryCodesLastIndex;
 	WlanCountryCode WlanCountryCodes[WlanCountryCodesNum];
@@ -59,9 +59,9 @@ struct PRODINFO {
 	u8 WlanMacAddress[6];
 	padding[0x10 - 6];
 	u8 BdAddress[6];
-	
+
 	padding[0x10 - 6];
-	
+
 	u8 AccelerometerOffset[6];
 	padding[2];
 	u8 AccelerometerScale[6];
@@ -70,50 +70,50 @@ struct PRODINFO {
 	padding[2];
 	u8 GyroscopeScale[6];
 	padding[2];
-	
+
 	char SerialNumber[0x18];
-	
+
 	padding[8];
-	
+
 	Cert EccP256Certificate;
 	Cert EccB233Certificate;
-	
+
 	Cert Ecc256ETicket;
 	Cert Ecc233ETicket;
-	
+
 	u8 SslKey[0x110];
 	padding[0x10];
 	u32 SslCertificateSize;
 	padding[0x0C];
 	u8 SslCertificate[0x800];
 	u8 SslCertificateHash[0x20];
-	
+
 	u8 RandomNumber[0x1000];
 	u8 RandomNumberHash[0x20];
-	
+
 	u8 GameCardKey[0x110];
 	u8 GameCardCertificate[0x400];
 	padding[0x10];
 	u8 GameCardCertificateHash[0x20];
-	
+
 	u8 Rsa2048ETicketKey[0x220];
 	padding[0x10];
 	u8 Rsa2048ETicketCertificate[0x240];
-	
+
 	padding[0x10];
-	
+
 	char BatteryLot[0x18];
-	
+
 	padding[0x08];
-	
+
 	u8 SpeakerCalibrationValue[0x800];
-	
+
 	padding[0x10];
-	
+
 	RegionCode RegionCode;
-	
+
 	padding[0x0C];
-	
+
 	u8 AmiiboKey[0x50];
 	padding[0x10];
 	u8 AmiiboEcqvCertificate[0x14];
@@ -125,21 +125,21 @@ struct PRODINFO {
 	u8 AmiiboEcqvBlsCertificate[0x20];
 	padding[0x10];
 	u8 AmiiboEcqvBlsRootCertificate[0x90];
-	
+
 	padding[0x10];
-	
+
 	ProductModel ProductModel;
-	
+
 	padding[0x0C];
-	
+
 	u8 ColorVariation[6];
-	
+
 	padding[0x0A];
-	
+
 	u8 LcdBacklightBrightnessMapping[0x0C];
-	
+
 	padding[0x04];
-	
+
 	u8 ExtendedEccB233DeviceKey[0x50];
 	padding[0x10];
 	u8 ExtendedEccP256ETicketKey[0x50];
@@ -153,19 +153,19 @@ struct PRODINFO {
 	u8 ExtendedGameCardKey[0x130];
 	padding[0x10];
 	u32 LcdVendorId;
-	
+
 	padding[0x0C];
-	
+
 	u8 ExtendedRsa2048DeviceKey[0x240];
 	padding[0x10];
 	u8 Rsa2048DeviceCertificate[0x240];
-	
+
 	padding[0x10];
-	
+
 	u8 UsbTypeCPowerSourceCircuitVersion;
-	
+
 	padding[0x0F];
-	
+
 	u32 HousingSubColor;
 	padding[0x0C];
 	u32 HousingBezelColor;
@@ -175,9 +175,9 @@ struct PRODINFO {
 	u32 HousingMainColor2;
 	padding[0x0C];
 	u32 HousingMainColor3;
-	
+
 	padding[0x0C];
-	
+
 	u8 AnalogStickModuleTypeL;
 	padding[0x0F];
 	u8 AnalogStickModelParameterL[0x12];
@@ -189,9 +189,9 @@ struct PRODINFO {
 	u8 AnalogStickModelParameterR[0x12];
 	padding[0x0E];
 	u8 AnalogStickFactoryCalibrationR[0x09];
-	
+
 	padding[0x07];
-	
+
 	u8 ConsoleSixAxisSensorModuleType;
 	padding[0x0F];
 	u8 ConsoleSixAxisSensorHorizontalOffset[6];

--- a/patterns/protobuf.hexpat
+++ b/patterns/protobuf.hexpat
@@ -66,7 +66,7 @@ struct LengthDelimited {
 
 struct Entry {
     Key key;
-	
+
 	if (wire_type == WireType::Varint)
 		type::uLEB128 value;
 	else if (wire_type == WireType::_64Bit)

--- a/patterns/pyc.hexpat
+++ b/patterns/pyc.hexpat
@@ -59,7 +59,7 @@ struct MarshalString {
         u8 length;
     else
         u32 length;
-        
+
     char data[length];
 };
 
@@ -67,50 +67,50 @@ struct MarshalSequence {
     if(parent.type == TYPE_SMALL_TUPLE)
         u8 length;
     else
-        u32 length;    
-    MarshalObject values[length];  
+        u32 length;
+    MarshalObject values[length];
 };
 
 struct MarshalCode {
     if(between(1, 3, 2, 3)) u16 numArgs;
     else if(above(2, 3)) u32 numArgs;
-    
+
     if(above(3, 8)) u32 numPosOnlyArgs;
-    
+
     if(_major >= 3) u32 numKwOnlyArgs;
-    
+
     if(between(1, 3, 2, 3)) u16 numLocals;
     else if(between(2, 3, 3, 11)) u32 numLocals;
-    
+
     if(between(1, 5, 2, 3)) u16 numStack;
     else if(above(2, 3)) u32 numStack;
-    
+
     if(between(1, 3, 2, 3)) u16 flags;
     else if(above(2, 3)) u32 flags;
-    
+
     MarshalObject code;
     MarshalObject constants;
     MarshalObject names;
-    
+
     if(above(1, 3)) MarshalObject localNames;
-    
+
     if(above(3, 11)) MarshalObject localKinds;
-    
+
     if(between(2, 1, 3, 11)) {
         MarshalObject freeVars;
         MarshalObject cellVars;
     }
-    
+
     MarshalObject fileName;
     MarshalObject name;
-    
+
     if(above(3, 11)) MarshalObject qualifiedName;
-    
+
     if(between(1, 5, 2, 3)) u16 firstLine;
     else if(above(2, 3)) u32 firstLine;
-    
+
     if(above(1, 5)) MarshalObject lnTable;
-    
+
     if(above(3, 11)) MarshalObject exceptionTable;
 };
 
@@ -120,7 +120,7 @@ struct DictEntry {
     MarshalObject value;
 };
 
-struct MarshalDict { 
+struct MarshalDict {
    DictEntry entries[while(true)];
 };
 
@@ -156,11 +156,11 @@ struct MarshalObject {
     u8 _type [[hidden]];
     u8 flag = _type & FLAG_REF;
     u8 type = _type & ~FLAG_REF;
-    
+
     if(flag) {
         refMember($-1);
     }
-    
+
     match(type) {
         (TYPE_NULL | TYPE_NONE | TYPE_STOPITER | TYPE_ELLIPSIS | TYPE_FALSE | TYPE_TRUE): continue;
         (TYPE_CODE): {
@@ -210,7 +210,7 @@ struct MarshalObject {
             std::print("Unknown marshal object type: {:c}", type);
         }
     }
-    
+
 } [[format("format_marshal")]];
 
 fn format_marshal(ref auto obj) {
@@ -313,23 +313,23 @@ struct PYCHeader {
     _minor = getMinor(magic);
     u8 major = _major [[export]];
     u8 minor = _minor [[export]];
-    
+
     if(above(3, 7)) {
         u32 flags;
     } else {
         u32 flags;
     }
-    
+
     if(flags & 0x1) {
         u64 checksum;
     } else {
         type::time32_t timestamp;
-        
+
         if(above(3, 3)) {
             u32 size;
         }
     }
-    
+
     MarshalObject object;
 };
 

--- a/patterns/pyinstaller.hexpat
+++ b/patterns/pyinstaller.hexpat
@@ -65,9 +65,9 @@ enum TypeCode : u8 {
 struct TOC {
     s32 structLen;
     u32 pos;
-    u32 len[[comment("len of the data (compressed)")]];;
-    u32 uLen[[comment("len of data (uncompressed)")]];;
-    bool cFlag[[comment("is it compressed")]];;
+    u32 len[[comment("len of the data (compressed)")]];
+    u32 uLen[[comment("len of data (uncompressed)")]];
+    bool cFlag[[comment("is it compressed")]];
     TypeCode typcd;
     char name[this.structLen - tocStructLength];
 

--- a/patterns/pyinstaller.hexpat
+++ b/patterns/pyinstaller.hexpat
@@ -1,10 +1,10 @@
-#pragma description PyInstaller binray 
+#pragma description PyInstaller binray
 
 #pragma endian big
 
 import std.mem;
 
-// Reference: 
+// Reference:
 //     https://pyinstaller.org/en/stable/advanced-topics.html
 
 //  typedef struct _cookie {
@@ -59,7 +59,7 @@ enum TypeCode : u8 {
     Module = 109,
     Script = 115,
     Data = 120,
-    RuntimeOption = 111, 
+    RuntimeOption = 111,
 };
 
 struct TOC {
@@ -70,7 +70,7 @@ struct TOC {
     bool cFlag[[comment("is it compressed")]];;
     TypeCode typcd;
     char name[this.structLen - tocStructLength];
-    
+
     if(typcd == TypeCode::Zlib) {
         ZlibArchive zlibArchive @ startOffset + this.pos;
     }

--- a/patterns/quantized-mesh.hexpat
+++ b/patterns/quantized-mesh.hexpat
@@ -25,15 +25,15 @@ struct QuantizedMeshHeader {
     double CenterX;
     double CenterY;
     double CenterZ;
-    
+
     float MinimumHeight;
     float MaximumHeight;
-    
+
     double BoundingSphereCenterX;
     double BoundingSphereCenterY;
     double BoundingSphereCenterZ;
     double BoundingSphereRadius;
-    
+
     double HorizonOcclusionPointX;
     double HorizonOcclusionPointY;
     double HorizonOcclusionPointZ;
@@ -112,11 +112,11 @@ fn format_oct16(Oct16 oct) {
     float xOut;
     float yOut;
     float zOut;
-    
+
     xOut = fromSnorm(oct.x);
     yOut = fromSnorm(oct.y);
     zOut = 1.0 - (std::math::abs(xOut) + std::math::abs(yOut));
-    
+
     if (zOut < 0.0) {
         float oldX;
 
@@ -124,7 +124,7 @@ fn format_oct16(Oct16 oct) {
         xOut = (1.0 - std::math::abs(yOut)) * signNotZero(oldX);
         yOut = (1.0 - std::math::abs(oldX)) * signNotZero(yOut);
     }
-    
+
     return std::format("{}, {}, {}", xOut, yOut, zOut);
 };
 
@@ -154,7 +154,7 @@ struct ExtensionHeader {
 struct QuantizedMesh {
     QuantizedMeshHeader header;
     VertexData vertdata;
-    
+
     if (vertdata.vertexCount > 65536) {
         IndexData32 indexdata;
         EdgeIndices32 edgeindices;
@@ -162,7 +162,7 @@ struct QuantizedMesh {
         IndexData16 indexdata;
         EdgeIndices16 edgeindices;
     }
-    
+
     ExtensionHeader extensions[extensionCount];
 };
 

--- a/patterns/ras.hexpat
+++ b/patterns/ras.hexpat
@@ -12,20 +12,20 @@ struct RAS{
 
   //Magic Bytes
   type::Magic<"\x59\xa6\x6a\x95"> signature;
- 
+
   //BE -> px -> mm
   u32 width [[name("Width")]];
   u32 height [[name("Height")]];
-  
+
   //BE
   u32 depth;
   u32 length;
   u32 type;
   u32 colorMapType;
   u32 colorMapLenght;
-  
+
   //Data Viewer
-  u8 image_data[length]; 
+  u8 image_data[length];
 };
 
 RAS header @0x00;

--- a/patterns/refs.hexpat
+++ b/patterns/refs.hexpat
@@ -1,6 +1,6 @@
 #pragma author 5h4rrK // https://www.github.com/5h4rrK
 #pragma organization temabi0s // (https://bi0s.in)
-#pragma description ReFS-File-System 
+#pragma description ReFS-File-System
 
 #pragma array_limit 10000
 
@@ -97,7 +97,7 @@ struct INDEX_HEADER {
 	u64 unused2[[name("UnUsed")]];
 	u32 end[[name("KeyIndexEnd")]];
 	u32 align[[name("Alignment")]];
-	$ = this.parent.start_pos + 0x50 + this.parent.rootsize + keyindxoff;	
+	$ = this.parent.start_pos + 0x50 + this.parent.rootsize + keyindxoff;
 	OFFSET_ENTRIES entries[keycount][[name("KeyEntries")]];
 
 };
@@ -142,7 +142,7 @@ struct ROOT_NODE{
 	char comps[rootsize - ($ - start_pos) + 0x50][[name("Components")]];
 	$ = (start_pos + 0x50 + rootsize);
 	INDEX_HEADER indxhdr[[name("IndexHeader")]];
-	// $ = start_pos + 0x50 + rootsize + indxhdr.keyindxoff;	
+	// $ = start_pos + 0x50 + rootsize + indxhdr.keyindxoff;
 	$ = (start_pos + 0x50 + rootsize + indxhdr.size);
 	INDEX_ENTRY_STRUCTURE indxentrystruct[indxhdr.keycount][[name("IndexEntry")]];
 };
@@ -214,7 +214,7 @@ struct CHECKPOINT {
 	u32 lenselfdescriptor[[comment("Self Descriptor Size"),name("SelfDescriptorSz")]];
 	u64 blockno[[comment("Most Recent CheckPoint") , name("BlockNumber")]];
 	u32 prev_pos = $;
-	$ = ($ / clustersz) *clustersz  + offsetselfdescriptor; 
+	$ = ($ / clustersz) *clustersz  + offsetselfdescriptor;
 	SELF_DESCRIPTOR selfdes[[name("SelfDescriptor")]];
 	$ = prev_pos;
 	$ += (0x28);

--- a/patterns/refs.hexpat
+++ b/patterns/refs.hexpat
@@ -238,7 +238,7 @@ struct SUPERBLOCK {
 };
 
 struct VOLUME_BOOT_RECORD {
-	BYTE jmpInstruction[3] [[comment("Jump Instruction"), name("JumpInstruction")]];;
+	BYTE jmpInstruction[3] [[comment("Jump Instruction"), name("JumpInstruction")]];
 	FILESYSTEM FileSystem[[comment("FileSystemName"), name("FileSystem")]];
 	BYTE UnKnown[5];
 	char Identifier[4][[comment("File System Recognition Structure, allows OS to recognise the structure"), name("FSRSIdentifier")]];

--- a/patterns/rgbds.hexpat
+++ b/patterns/rgbds.hexpat
@@ -33,7 +33,7 @@ namespace fstack {
             LONG iters[depth];
         }
     };
-        
+
     LONG nbNodes @ $;
     Node nodes[nbNodes] @ $;
 }
@@ -54,7 +54,7 @@ namespace sym {
             LONG value;
         }
     };
-    
+
     Symbol symbols[nbSym] @ $;
 }
 
@@ -75,7 +75,7 @@ namespace sect {
         LONG rpnSize;
         BYTE rpn[rpnSize];
     };
-    
+
     enum Type : BYTE {
         WRAM0,
         VRAM,
@@ -105,7 +105,7 @@ namespace sect {
             Patch patches[nbPatches];
         }
     };
-    
+
     Section sections[nbSect] @ $;
 }
 
@@ -126,7 +126,7 @@ namespace assert {
         BYTE rpn[rpnSize];
         STRING msg;
     };
-    
+
     LONG nbAsserts @ $;
     Assertion assertions[nbAsserts] @ $;
 }

--- a/patterns/selinux.hexpat
+++ b/patterns/selinux.hexpat
@@ -99,7 +99,7 @@ struct expression {
     if ((type_g == policy_types::kernel && version >= 29) ||
         (type_g != policy_types::kernel))
         type_set type_names;
-    } 
+    }
 };
 
 struct constraint {
@@ -235,12 +235,12 @@ struct user_s {
     if (boundary_feature)
         u32 bounds;
     char key[length];
-    
+
     if (type_g == policy_types::kernel)
         extensible_bitmap roles;
     else
         role_set roles;
-    
+
     if ((type_g == policy_types::kernel && version >= 19) || (type_g == policy_types::module && version >= 5 && version < 6) || (type_g == policy_types::base && version >= 5 && version < 6)) {
         mls_range exp_range;
         mls_level exp_dftlevel;
@@ -258,7 +258,7 @@ struct bool_ { // conditional boolean
     u32 state;
     u32 length;
     char key[length];
-    if ((type_g != policy_types::kernel && version >= 14)) 
+    if ((type_g != policy_types::kernel && version >= 14))
         u32 flags;
 };
 using bools = symbols_list<bool_>;
@@ -289,7 +289,7 @@ struct symbols {
     if (symbols_count >= 6)
         bools bools;
     if (symbols_count >= 7)
-        sensitivity_levels levels; 
+        sensitivity_levels levels;
     if (symbols_count >= 8)
         categories cats;
 };
@@ -429,7 +429,7 @@ struct filename_trans_item {
 struct role_trans_rule_item {
     role_set roles;
     role_set types;
-    if (version >= 12) 
+    if (version >= 12)
         extensible_bitmap classes;
     u32 new_role;
 };
@@ -468,7 +468,7 @@ struct filename_trans_rule_item {
     u32 tclass;
     u32 otype;
 
-    if (version >= 21) 
+    if (version >= 21)
         u32 flags;
 };
 using filename_trans_rule = list<filename_trans_rule_item>;
@@ -668,10 +668,10 @@ struct Header {
     if (magic == magics::kernel)
         type_g = policy_types::kernel;
     else
-    if (policy_subtype == policy_types::module) 
+    if (policy_subtype == policy_types::module)
         type_g = policy_types::module;
     else
-        type_g = policy_types::base;        
+        type_g = policy_types::base;
     u32 __policyvers;
     version = __policyvers;
     boundary_feature = (type_g == policy_types::kernel && version >= 24) || (type_g != policy_types::kernel && version >= 9);
@@ -680,7 +680,7 @@ struct Header {
     u32 symbols_count_;
     symbols_count = symbols_count_;
     std::assert(0 <= symbols_count && symbols_count <= 9, "Invalid 'symbols_count' value.");
-    u32 object_contexts_count_; 
+    u32 object_contexts_count_;
     object_contexts_count = object_contexts_count_;
     std::assert(0 <= object_contexts_count && object_contexts_count <= 9, "Invalid 'object_contexts_count' value.");
     if (magic == magics::module)

--- a/patterns/sit5.hexpat
+++ b/patterns/sit5.hexpat
@@ -17,19 +17,19 @@ namespace v5 {
         encrypted : 1;
         padding : 5;
     };
-    
+
     bitfield Flags2 {
         padding : 7;
         resource_fork : 1;
         padding : 8;
     };
-    
+
     using MacOSHFSPlusDate = u32 [[format("v5::format_macos_date")]];
-    
+
     fn format_macos_date(MacOSHFSPlusDate date) {
         return std::time::format(std::time::to_utc(date - 2082844800));
     };
-    
+
     struct Header {
         char magic[0x50];
         u32 unknown1;
@@ -37,7 +37,7 @@ namespace v5 {
         u32 entriesOffset;
         u32 unknown2;
     };
-    
+
     struct EntryHeader {
         u32 magic;
         u8 version;
@@ -49,12 +49,12 @@ namespace v5 {
         u32 prevEntryOffset, nextEntryOffset, parentEntryOffset;
         u16 nameSize;
         u16 headerChecksum;
-        
+
         u32 dataForkUncompressedLength, dataForkCompressedLength;
         u16 dataForkChecksum;
         u16 unknown3;
     };
-    
+
     enum CompressionMethod : u8 {
         None            = 0x00, // No compression
         Rle90           = 0x01, // Run length encoding
@@ -66,25 +66,25 @@ namespace v5 {
         Stuffit14       = 0x0E, // Unknown
         StuffItArsenic  = 0x0F  // BWT and arithmetic coding
     };
-    
+
     struct Entry {
         EntryHeader header;
         if (header.flags.folder) {
             u16 numFiles;
-            
+
             if (header.dataForkUncompressedLength)
                 std::print("Folder entry {} is special!", std::core::array_index());
         } else {
             CompressionMethod compressionMethod;
         }
-        
+
         u8 passwordDataLength;
         u8 passwordInformation[passwordDataLength];
         char fileName[header.nameSize];
         u16 commentSize;
         u16 unknown2;
         char comment[commentSize];
-        
+
         if (!header.flags.folder) {
             Flags2 flags;
             u16 unknown3;
@@ -94,25 +94,25 @@ namespace v5 {
             u32 unknown4;
             u32 unknown5;
             u8 unknown6[6];
-            
+
             if (header.version == 1)
                 u32 unknown7;
-                            
+
             u8 compressedData[header.dataForkCompressedLength] [[sealed]];
-            
+
             if (header.nextEntryOffset == 0x00)
                 break;
             else
                 $ = header.nextEntryOffset;
         }
     };
-    
+
     struct StuffIt {
         Header header;
-        
+
         Entry entries[while(true)] @ header.entriesOffset;
     };
-    
+
 }
 
 v5::StuffIt stuffIt @ 0x00;

--- a/patterns/stl.hexpat
+++ b/patterns/stl.hexpat
@@ -30,7 +30,7 @@ struct BinarySTLHeader {
     u32 triangleCount;
 };
 
-struct STL {    
+struct STL {
     if (std::mem::read_string(0, 6) == "solid ")
         std::warning("ASCII STL file!");
     else {

--- a/patterns/tar.hexpat
+++ b/patterns/tar.hexpat
@@ -61,7 +61,7 @@ struct posix_header {
 struct tar {
     posix_header header_raw;
     char file[octal_to_decimal(header_raw.size)];
-    
+
     std::print("-" * 50);
     std::print("File Name: {}", header_raw.name);
     std::print("File Permissions: {}" , header_raw.mode);
@@ -78,7 +78,7 @@ struct tar {
     std::print("devmajor: {}", header_raw.devmajor);
     std::print("devminor: {}", header_raw.devminor);
     std::print("prefix: {}", header_raw.prefix);
-    
+
     char empty[while (std::mem::read_string($, 1) == NULL && !std::mem::eof())];
     if (std::mem::eof()) {
         break;

--- a/patterns/tga.hexpat
+++ b/patterns/tga.hexpat
@@ -61,7 +61,7 @@ struct Header {
   ColorMapSpec colorMapSpec;
   ImageSpec    imageSpec;
   char         imageId[idLength];
-  
+
   if (colorMapType == ColorMapType::ColorPalette) {
     u8 colorMapData[GetColorMapDataSize(colorMapSpec)];
   }

--- a/patterns/ttf.hexpat
+++ b/patterns/ttf.hexpat
@@ -159,7 +159,7 @@ struct CmapSubtable12 : BaseCmapSubtable {
 
 struct CmapSubtable {
     u16 format = std::mem::read_unsigned($, 2, std::mem::Endian::Big);
-    
+
     match (format) {
         (0): CmapSubtable0 table [[inline]];
         (2): CmapSubtable2 table [[inline]];
@@ -184,12 +184,12 @@ struct EncodingRecord {
     CmapPlatform platformId;
     u16 encodingId;
     u32 offset;
-    
+
     u64 endEncodingRecord = $;
     $ = startOfCmapTable + offset;
-    
+
     CmapSubtable subtable;
-    
+
     $ = endEncodingRecord;
 };
 
@@ -334,7 +334,7 @@ struct CompositeGlyphTable : GlyphTableHeader {
 
 struct GlyfTable {
     s16 type = std::mem::read_signed($, 2, std::mem::Endian::Big);
-    
+
     if (type >= 0) {
         SimpleGlyphTable table [[inline]];
     } else {
@@ -553,7 +553,7 @@ struct NameTableV1 : NameTableV0 {
 
 struct NameTable {
     u16 version = std::mem::read_unsigned($, 2, std::mem::Endian::Big);
-    
+
     match (version) {
         (0): NameTableV0 table [[inline]];
         (_): NameTableV1 table [[inline]];
@@ -613,7 +613,7 @@ struct OS2TableV5 : OS2TableV4 {
 
 struct OS2Table {
     u16 version = std::mem::read_unsigned($, 2, std::mem::Endian::Big);
-    
+
     match (version) {
         (0): OS2TableV0 table [[inline]];
         (1): OS2TableV1 table [[inline]];
@@ -648,10 +648,10 @@ struct PostTableV2 : PostTableV1 {
 struct PostTable {
     u16 major = std::mem::read_unsigned($, 2, std::mem::Endian::Big);
     u16 minor = std::mem::read_unsigned($ + 2, 2, std::mem::Endian::Big);
-    
+
     match (major, minor) {
         (2, 0): PostTableV2 table [[inline]];
-        (_, _): PostTableV1 table [[inline]]; 
+        (_, _): PostTableV1 table [[inline]];
     }
 };
 
@@ -715,11 +715,11 @@ struct TTF {
     u16 searchRange;
     u16 entrySelector;
     u16 rangeShift;
-    
+
     u64 start = $;
     HiddenForPreprocessing hidden[numTables] [[hidden]];
     $ = start;
-    
+
     Table tables[numTables];
 };
 

--- a/patterns/uefi.hexpat
+++ b/patterns/uefi.hexpat
@@ -2,7 +2,7 @@
 
 #define WIN_CERT_TYPE_PKCS_SIGNED_DATA 0x0002
 #define WIN_CERT_TYPE_EFI_PKCS115   0x0EF0
-#define WIN_CERT_TYPE_EFI_GUID     0x0EF1 
+#define WIN_CERT_TYPE_EFI_GUID     0x0EF1
 
 struct EFI_TIME {
  u16  Year;             // 1900 – 9999

--- a/patterns/uefi_boot_entry.hexpat
+++ b/patterns/uefi_boot_entry.hexpat
@@ -25,7 +25,7 @@ struct FILE_PATH {
 // subsection 10.3.1
 enum MEDIA_DEVICE_PATH_SUBTYPE : u8 {
   HARD_DRIVE = 0x01,
-  FILE_PATH = 0x04,  
+  FILE_PATH = 0x04,
 };
 
 enum DEVICE_PATH_TYPE : u8 {
@@ -42,10 +42,10 @@ struct DEVICE_PATH {
     // the size of the data is the size of the structure minus the fields we know.
     // not always used
     u16 dataSize = length-1-1-2;
-    
+
     match (type, subtype) {
         (DEVICE_PATH_TYPE::MEDIA_DEVICE_PATH, MEDIA_DEVICE_PATH_SUBTYPE::HARD_DRIVE): HARD_DRIVE data;
-        (DEVICE_PATH_TYPE::MEDIA_DEVICE_PATH, MEDIA_DEVICE_PATH_SUBTYPE::FILE_PATH): FILE_PATH data;                              
+        (DEVICE_PATH_TYPE::MEDIA_DEVICE_PATH, MEDIA_DEVICE_PATH_SUBTYPE::FILE_PATH): FILE_PATH data;
         (_, _): u8 data[dataSize];
     }
 };

--- a/patterns/uf2.hexpat
+++ b/patterns/uf2.hexpat
@@ -131,7 +131,7 @@ struct UF2_ExtensionTag {
 	u8 size;
 	UF2_TagType type;
 	u8 data[size - 4];
-	
+
 	if (size == 0 && type.bytes[0] == 0x00 && type.bytes[1] == 0x00 && type.bytes[2] == 0x00)
 		break;
 };
@@ -144,26 +144,26 @@ struct UF2_Block {
     u32 payloadSize;
     u32 blockNo;
     u32 numBlocks;
-    
+
     if (flags.FamilyIDPresent)
     	UF2_FamilyID familyId;
     else
     	u32 fileSize;
-    
+
     if (flags.MD5ChecksumPresent) {
     	u8 data[452];
-    	UF2_Hash hash; 
+    	UF2_Hash hash;
     }
     else {
     	u8 data[476];
     }
-    
+
     if (flags.ExtensionTagsPresent) {
 		UF2_ExtensionTag extensionTags[0xFF];
     }
-    
+
     u32 magicEnd;
-    
+
     std::assert(magicStart0 == "UF2\n", "Invalid magicStart0 value!");
     std::assert(magicStart1 == 0x9E5D5157, "Invalid magicStart1 value!");
     std::assert(magicEnd == 0x0AB16F30, "Invalid magicEnd value!");

--- a/patterns/usb.hexpat
+++ b/patterns/usb.hexpat
@@ -19,7 +19,7 @@ enum DescriptorType : u8 {
     OTGDescriptor                       = 0x09,
     DebugDescriptor                     = 0x0A,
     InterfaceAssociationDescriptor      = 0x0B,
-    
+
     HIDDescriptor                       = 0x21,
     ReportDescriptor                    = 0x22,
     PhysicalDescriptor                  = 0x23
@@ -130,7 +130,7 @@ fn format_bcd(ref auto bcd) {
     str result;
     for (s8 i = sizeof(bcd.bytes) - 1, i >= 0, i -= 1)
         result += std::format("{:X}.", bcd.bytes[i]);
-        
+
     return std::string::substr(result, 0, std::string::length(result) - 1);
 };
 
@@ -168,7 +168,7 @@ struct InterfaceDescriptor {
     u8 bInterfaceNumber;
     u8 bAlternateSetting;
     u8 bNumEndpoints;
-    
+
     InterfaceClass bInterfaceClass;
     if (bInterfaceClass == InterfaceClass::Hub) {
         HubInterfaceSubClass bInterfaceSubClass;
@@ -183,7 +183,7 @@ struct InterfaceDescriptor {
         u8 bInterfaceSubClass;
         u8 bInterfaceProtocol;
     }
-    
+
     u8 iInterface;
 };
 
@@ -248,7 +248,7 @@ struct HIDDescriptor {
 struct USBDescriptor {
     u8 bLength;
     DescriptorType bDescriptorType;
-    
+
     if (bDescriptorType == DescriptorType::DeviceDescriptor)
         DeviceDescriptor deviceDescriptor [[inline]];
     else if (bDescriptorType == DescriptorType::ConfigDescriptor)
@@ -267,7 +267,7 @@ struct USBDescriptor {
         OTGDescriptor otgDescriptor [[inline]];
     else if (bDescriptorType == DescriptorType::HIDDescriptor)
         HIDDescriptor hidDescriptor [[inline]];
-    
+
     padding[bLength - ($ - addressof(this))];
 };
 

--- a/patterns/vbmeta.hexpat
+++ b/patterns/vbmeta.hexpat
@@ -157,7 +157,7 @@ struct AvbDescriptor<auto end> {
   AvbDescriptorTag tag;
   uint64_t num_bytes_following;
   u8 data[num_bytes_following] [[hidden]];
-  
+
   match (tag) {
     (AvbDescriptorTag::AVB_DESCRIPTOR_TAG_PROPERTY)       : AvbPropertyDescriptor descriptor @ addressof(data);
     (AvbDescriptorTag::AVB_DESCRIPTOR_TAG_HASHTREE)       : AvbHashtreeDescriptor descriptor @ addressof(data);
@@ -204,7 +204,7 @@ struct AvbVBMetaImage
                      header.hash_offset, header.hash_size,
                      header.signature_offset, header.signature_size>
     authentication_data;
-  
+
   AuxiliaryData<header.auxiliary_data_block_size,
                 header.public_key_offset, header.public_key_size,
                 header.public_key_metadata_offset, header.public_key_metadata_size,

--- a/patterns/vdf.hexpat
+++ b/patterns/vdf.hexpat
@@ -15,9 +15,9 @@ enum Type : u8 {
 
 struct Entry {
 	Type type;
-	
+
 	char name[];
-	
+
 	if (type == Type::Set) {
 		Entry entries[while (std::mem::read_unsigned($, 1) != Type::EndSet)];
 		Type endSet [[hidden]];

--- a/patterns/vgm.hexpat
+++ b/patterns/vgm.hexpat
@@ -18,9 +18,9 @@ bitfield VGMVersion {
     bugfix : 4;
     minor : 4;
     major : 24;
-    
+
     versionValue = major * 100 + minor * 10 + bugfix;
-    
+
 } [[format("format_VGMVersion")]];
 
 fn format_VGMVersion(auto version) {
@@ -224,7 +224,7 @@ struct ExtraHeader {
     u32 chpClkOffset;
     chpVolBase = $;
     u32 chpVolOffset;
-    
+
     if (chpClkOffset > 0) {
         $ = chpClkBase + chpClkOffset;
         chpClkHeader chpClk;
@@ -232,7 +232,7 @@ struct ExtraHeader {
         $ = chpVolBase + chpVolOffset;
         chpVolHeader chpVol;
     }
-    
+
 };
 
 struct VGM {

--- a/patterns/vhdx.hexpat
+++ b/patterns/vhdx.hexpat
@@ -38,7 +38,7 @@ struct DataDescriptor {
 
 struct LogDescriptor {
 	char signature[4];
-	
+
 	if (signature == "zero")
 		ZeroDescriptor descriptor [[inline]];
 	else if (signature == "desc")
@@ -103,7 +103,7 @@ struct ParentLocatorEntry {
 	u32 valueOffset;
 	u16 keyLength;
 	u16 valueLength;
-	
+
 	char16 key[keyLength / 2] @ addressof(parent) + keyOffset;
 	char16 value[valueLength / 2] @ addressof(parent) + valueOffset;
 };
@@ -161,7 +161,7 @@ struct RegionTable {
 	u32 checksum;
 	u32 entryCount;
 	padding[4];
-	
+
 	RegionTableEntry entries[entryCount];
 };
 

--- a/patterns/wad.hexpat
+++ b/patterns/wad.hexpat
@@ -13,7 +13,7 @@ struct FileLump {
     u32 filePos;
     type::Size<u32> size;
     char name[8];
-    
+
     u8 data[size] @ filePos [[sealed]];
 };
 

--- a/patterns/wav.hexpat
+++ b/patterns/wav.hexpat
@@ -53,7 +53,7 @@ struct WaveFormatPCM {
 };
 
 struct WaveMSADPCMCoefSet {
-  s16 coef1;    
+  s16 coef1;
   s16 coef2;
 };
 

--- a/patterns/webp.hexpat
+++ b/patterns/webp.hexpat
@@ -116,7 +116,7 @@ struct WebPData {
             padding[paddedChunkSize - sizeof(data)];
         }
     }
-} [[name(std::format("Chunk ({})", chunkHeader.chunkId))]];;
+} [[name(std::format("Chunk ({})", chunkHeader.chunkId))]];
 
 RiffHeader header @0x00;
 WebPData data[while (!std::mem::eof())] @ $;

--- a/patterns/webp.hexpat
+++ b/patterns/webp.hexpat
@@ -79,7 +79,7 @@ struct WebPANMFData {
     u24 frameDuration;
     ANMFFlags flags;
     u8 data[parent.chunkHeader.chunkSize - 16]; // lazy fix - can't be bothered implementing subchunks
-    
+
 };
 
 bitfield ALPHFlags {
@@ -97,7 +97,7 @@ struct WebPData {
     match (chunkHeader.chunkId) {
         ("VP8X"): WebPVP8XData VP8XData;
         ("ANIM"): WebPANIMData ANIMData;
-        ("ANMF"): { 
+        ("ANMF"): {
             WebPANMFData ANMFData;
             padding[paddedChunkSize - sizeof(ANMFData)];
         }

--- a/patterns/wintec_tes.hexpat
+++ b/patterns/wintec_tes.hexpat
@@ -1,6 +1,6 @@
 // Wintec TES file
 //
-// Wintec produced small GPS-Loggers that created TES files. Each file 
+// Wintec produced small GPS-Loggers that created TES files. Each file
 // is a series of timestamps and coordinates. The format is exceedingly
 // simple. The same 16 byte struct is repeated from start to finish.
 //

--- a/patterns/xbeh.hexpat
+++ b/patterns/xbeh.hexpat
@@ -61,10 +61,10 @@ union EntryPoint {
     u32 betaAddress [[format("format_beta_entrypoint")]];
     u32 debugAddress [[format("format_debug_entrypoint")]];
     u32 retailAddress [[format("format_retail_entrypoint")]];
-    
+
     if ((betaAddress ^ 0xE682F45B) - parent.baseAddress < std::mem::size())
         u8 beta     @ (betaAddress ^ 0xE682F45B) - parent.baseAddress;;
-    if ((debugAddress ^ 0x94859D4B) - parent.baseAddress < std::mem::size())    
+    if ((debugAddress ^ 0x94859D4B) - parent.baseAddress < std::mem::size())
         u8 debug    @ (debugAddress ^ 0x94859D4B) - parent.baseAddress;;
     if ((retailAddress ^ 0xA8FC57AB) - parent.baseAddress < std::mem::size())
         u8 retail   @ (retailAddress ^ 0xA8FC57AB) - parent.baseAddress;
@@ -301,8 +301,8 @@ struct KernelImageThunk {
 union KernelImageThunkAddress {
     u32 debugAddress [[format("format_debug_kernel_image_thunk_address")]];
     u32 retailAddress [[format("format_retail_kernel_image_thunk_address")]];
-    
-    if ((debugAddress ^ 0xEFB1F152) - parent.baseAddress < std::mem::size())    
+
+    if ((debugAddress ^ 0xEFB1F152) - parent.baseAddress < std::mem::size())
         KernelImageThunk debug    @ (debugAddress ^ 0xEFB1F152) - parent.baseAddress;;
     if ((retailAddress ^ 0x5B6D40B6) - parent.baseAddress < std::mem::size())
         KernelImageThunk retail   @ (retailAddress ^ 0x5B6D40B6) - parent.baseAddress;
@@ -365,7 +365,7 @@ struct SectionHeader {
     u16 *headSharedPageReferenceCount : u32 [[pointer_base("relative_to_base_section")]];
     u16 *tailSharedPageReferenceCount : u32 [[pointer_base("relative_to_base_section")]];
     u8 sectionDigest[20];
-    
+
     u8 data[rawSize] @ rawAddress [[sealed]];
 };
 
@@ -381,7 +381,7 @@ struct XBEH {
     InitializationFlags initializationFlags;
     EntryPoint entrypoint;
     TLS *tls : u32 [[pointer_base("relative_to_base")]];
-    
+
     type::Size<u32> stackSize;
     u32 peHeapReserve, peHeapCommit, peBaseAddress;
     type::Size<u32> peImageSize;
@@ -399,7 +399,7 @@ struct XBEH {
     u32 logoBitMapAddress, logoBitmapSize;
     u64 unknown1;
     u32 unknown2;
-    
+
     u8 logoBitmap[logoBitmapSize] @ logoBitMapAddress - baseAddress;
 };
 

--- a/patterns/xbeh.hexpat
+++ b/patterns/xbeh.hexpat
@@ -63,9 +63,9 @@ union EntryPoint {
     u32 retailAddress [[format("format_retail_entrypoint")]];
 
     if ((betaAddress ^ 0xE682F45B) - parent.baseAddress < std::mem::size())
-        u8 beta     @ (betaAddress ^ 0xE682F45B) - parent.baseAddress;;
+        u8 beta     @ (betaAddress ^ 0xE682F45B) - parent.baseAddress;
     if ((debugAddress ^ 0x94859D4B) - parent.baseAddress < std::mem::size())
-        u8 debug    @ (debugAddress ^ 0x94859D4B) - parent.baseAddress;;
+        u8 debug    @ (debugAddress ^ 0x94859D4B) - parent.baseAddress;
     if ((retailAddress ^ 0xA8FC57AB) - parent.baseAddress < std::mem::size())
         u8 retail   @ (retailAddress ^ 0xA8FC57AB) - parent.baseAddress;
 };
@@ -303,7 +303,7 @@ union KernelImageThunkAddress {
     u32 retailAddress [[format("format_retail_kernel_image_thunk_address")]];
 
     if ((debugAddress ^ 0xEFB1F152) - parent.baseAddress < std::mem::size())
-        KernelImageThunk debug    @ (debugAddress ^ 0xEFB1F152) - parent.baseAddress;;
+        KernelImageThunk debug    @ (debugAddress ^ 0xEFB1F152) - parent.baseAddress;
     if ((retailAddress ^ 0x5B6D40B6) - parent.baseAddress < std::mem::size())
         KernelImageThunk retail   @ (retailAddress ^ 0x5B6D40B6) - parent.baseAddress;
 };

--- a/patterns/xci.hexpat
+++ b/patterns/xci.hexpat
@@ -57,7 +57,7 @@ struct CardHeader {
     u32 selT1Key;
     u32 selKey;
     u32 limArea;
-    
+
     u8 cardHeaderEncryptedData[0x70];
 };
 
@@ -86,15 +86,15 @@ struct PartitionFs {
     padding[4];
     FileEntry fileEntryTable[fileCount];
     String stringTable[while($ < (addressof(fileEntryTable) + sizeof(fileEntryTable) + stringTableSize))];
-    
+
     File files[fileCount];
 };
 
 struct XCI {
     CardHeader header;
-    
+
     PartitionFs x @ header.romAreaStartPageAddress * PAGE_SIZE;
-    
+
 };
 
 XCI xci @ 0x00;

--- a/patterns/xgspak.hexpat
+++ b/patterns/xgspak.hexpat
@@ -32,7 +32,7 @@ enum PakVersion : u8
 {
     Version0, //NFS Wii/Trilogy 3DS/DLS
     Version1, //ABGO V1/ABTF, AB Console Ports
-    Version2 //ABGO V2+    
+    Version2 //ABGO V2+
 };
 
 enum CompressionType : u32
@@ -67,7 +67,7 @@ struct XGSPakHeader
 struct XGSPakFolderBase
 {
     if (Head.ver == PakVersion::Version0)
-    {    
+    {
         char *name[] : u32[[pointer_base("offToStringTable")]];
         u32 filesInFolder;
         u32 subfolders;
@@ -102,7 +102,7 @@ struct XGSPakFolderBase
 struct XGSPakContentMeta
 {
     if (Head.ver == PakVersion::Version0)
-    {    
+    {
         char *name[] : u32 [[pointer_base("offToStringTable")]];
         u32 decompFileSize;
         u32 fileOff;

--- a/patterns/xgstexture.hexpat
+++ b/patterns/xgstexture.hexpat
@@ -92,7 +92,7 @@ bitfield XGSTextureFlags
 
 struct XGSTextureHeader
 {
-    type::Magic"XGST"> magic;
+    type::Magic<"XGST"> magic;
     u8 dataOffset;
     XGSPlatform compilationPlatform; //Definitely platform, this has no harm when modifying (except in Edge of Perception) but does help with knowing platform specific compressions, usually
     u16 headerSize; //?

--- a/patterns/xgstexture.hexpat
+++ b/patterns/xgstexture.hexpat
@@ -24,7 +24,7 @@ enum XGSPlatform : u8
     DURANGO, //Xbox One
     WINPHONE, //PCOGL
     WINPHONE_LEGACY, //WP8
-    APPLE_TV, //Apple TV    
+    APPLE_TV, //Apple TV
 };
 
 enum XGSTextureFormat : u16
@@ -43,17 +43,17 @@ enum XGSTextureFormat : u16
     PVR_UNK,                        //2BPP no alpha? Crashes in ABGO v101
     RGB888,                         //Greyscale? unused, crashes in EOP but works in ABGO v101
     AL88,
-    //14,                           //8BPP something? Crash on EOP and PS3, on ABGO v101, nothing 
-    PVRTC_2BPP_RGBA = 15,           //Crash on PS3, on ABGO v101, nothing 
-    PVRTC_4BPP_RGBA,                //Crash on PS3 or is this 2bppRGBA, on ABGO v101, nothing 
-    PVRTC_4BPP_RGBA_2,              //May need to swap these two, crash on PS3, on ABGO v101, nothing 
-    PVRTC_4BPP_RGBA_3,              //Crashes on EOP and PS3, on ABGO v101, nothing 
-    //19,                           //Crash on PS3 and EOP, on ABGO v101, nothing 
-    //20,                           //Crash on PS3 and EOP, on ABGO v101, nothing 
-    //21,                           //Crash on PS3 and EOP, on ABGO v101, nothing 
-    RG88_OR_GR88 = 22,              //Unused. On PS3, it's unswizzled GR88, crashes on EOP, on ABGO v101, nothing 
-    L4,                             //Unused, crashes on EOP, on ABGO v101, nothing 
-    DXT1_OR_ETC1,                   //On Android this is usually DXT1, old Android has this DXT1 swizzled, null on PS3, crash on EOP, on ABGO v101, nothing 
+    //14,                           //8BPP something? Crash on EOP and PS3, on ABGO v101, nothing
+    PVRTC_2BPP_RGBA = 15,           //Crash on PS3, on ABGO v101, nothing
+    PVRTC_4BPP_RGBA,                //Crash on PS3 or is this 2bppRGBA, on ABGO v101, nothing
+    PVRTC_4BPP_RGBA_2,              //May need to swap these two, crash on PS3, on ABGO v101, nothing
+    PVRTC_4BPP_RGBA_3,              //Crashes on EOP and PS3, on ABGO v101, nothing
+    //19,                           //Crash on PS3 and EOP, on ABGO v101, nothing
+    //20,                           //Crash on PS3 and EOP, on ABGO v101, nothing
+    //21,                           //Crash on PS3 and EOP, on ABGO v101, nothing
+    RG88_OR_GR88 = 22,              //Unused. On PS3, it's unswizzled GR88, crashes on EOP, on ABGO v101, nothing
+    L4,                             //Unused, crashes on EOP, on ABGO v101, nothing
+    DXT1_OR_ETC1,                   //On Android this is usually DXT1, old Android has this DXT1 swizzled, null on PS3, crash on EOP, on ABGO v101, nothing
     LA44,                           //Crash on EOP, on ABGO v101, nothing
     DXT5,                           //Crash on EOP, on ABGO v101, nothing
     //?,                            //Crash on EOP, on ABGO v101, nothing, note starting here PS3 crashes

--- a/patterns/xilinx_bit.hexpat
+++ b/patterns/xilinx_bit.hexpat
@@ -21,7 +21,7 @@ struct Command {
 
 fn format_command(Command command) {
 	u32 x = command.value;
-	
+
 	if (x == 0x20000000) return "NOP";
 	if (x == 0xAA995566) return "SYNC";
 	if (x == 0x000000BB) return "Bus Width Sync";
@@ -32,10 +32,10 @@ fn format_command(Command command) {
 	if (x == 0x30018001) return "Write to IDCODE";
 	if (x == 0x30004000) return "Write to FDRI";
 	if (x == 0x30008001) return "Write to CMD";
-	
+
 	if ((x & 0xF0000000) == 0x30000000)
 		return std::format("Write to Register {}", (x & 0x0003E000) >> 13);
-	
+
 	return std::format("0x{:08X}", x);
 };
 

--- a/patterns/zip.hexpat
+++ b/patterns/zip.hexpat
@@ -20,15 +20,15 @@ struct EndOfCentralDirectory {
 
 
 namespace extra {
-    
+
     bitfield Flags {
           bool modification_time_set : 1;
-          bool access_time_set : 1; 
+          bool access_time_set : 1;
           bool creation_time_set : 1;
           reserved: 5;  //reserved for additional timestamps; not set
     };
-    
-    struct X5455_ExtendedTimestamp {    
+
+    struct X5455_ExtendedTimestamp {
         Flags Flags;
         if (Flags.modification_time_set){
             u32 ModTime;
@@ -40,7 +40,7 @@ namespace extra {
             u32 CrTime;
         }
     };
-    
+
     struct X000A_NTFS {
         u32 reserved;
         u16 tag;
@@ -50,8 +50,8 @@ namespace extra {
         type::FILETIME AcTime;
         type::FILETIME CrTime;
     };
-    
-    struct X7875_NewUnix {    
+
+    struct X7875_NewUnix {
         u16 tag;
         u16 TSize;
         u8 version;
@@ -60,7 +60,7 @@ namespace extra {
         u8 GIDSize;
         u8 GID[GIDSize];
     };
-         
+
     struct X5855_InfoZipUnix {
         u32 AcTime;
         u32 ModTime;
@@ -71,7 +71,7 @@ namespace extra {
             u16 GID;
         }
     };
-    
+
     struct ExtraField {
         u16 tag;
         u16 TSize;
@@ -83,7 +83,7 @@ namespace extra {
             extra::X7875_NewUnix x7875_NewUnix;
         }else if (tag == 0x5855){
             extra::X5855_InfoZipUnix x5855_InfoZipUnix;
-        }else{    
+        }else{
             std::print("Unsupported tag 0x{:02X}", tag);
             padding[TSize];
         }
@@ -98,25 +98,25 @@ fn find_eocd() {
         return std::mem::size()-22;
     } else {
         // If it's not there, then there's probably a zip comment;
-        // search the last 64KB of the file for the signature.        
+        // search the last 64KB of the file for the signature.
         u128 offset_search_from = std::math::max(0, std::mem::size()-65536-22);
         u128 prev_address;
         while(1){
-            u128 current_address = std::mem::find_sequence_in_range(0, offset_search_from, std::mem::size(), 0x50,0x4B,0x05,0x06); 
-            
+            u128 current_address = std::mem::find_sequence_in_range(0, offset_search_from, std::mem::size(), 0x50,0x4B,0x05,0x06);
+
             //Reached EOF and did not find valid eocd.
             if (current_address == 340282366920938463463374607431768211455){
                 std::error("Could not find EOCD.");
             }
-            
+
             //Potential eocd found. Create a eocd struct
             EndOfCentralDirectory EOCD @ current_address;
-            
+
             //If central directory file header is valid, then we know the eocd offset is valid.
             if (std::mem::read_unsigned(EOCD.CDOffset, 4, std::mem::Endian::Little) == 0x2014B50){
                 return current_address;
             }
-            
+
             offset_search_from = current_address + 1;
             prev_address = current_address;
         }

--- a/patterns/zlib.hexpat
+++ b/patterns/zlib.hexpat
@@ -22,7 +22,7 @@ if (data_len > (HEADER_SIZE + CSUM_SIZE)) {
 /// Compression method; only Deflate is used
 enum CM: u8 {
     Deflate = 8,
-    Reserved = 15,  
+    Reserved = 15,
 };
 
 /// Compression level
@@ -43,7 +43,7 @@ bitfield Header {
 } [[bitfield_order(BitfieldOrder::LeastToMostSignificant, 16)]];
 
 
-/// Validate the header's checksum 
+/// Validate the header's checksum
 fn validate_hdr_checksum(Header hdr) {
     // Reassemble as a 2-byte big endian value
     u16 value = (
@@ -53,7 +53,7 @@ fn validate_hdr_checksum(Header hdr) {
         (hdr.fdict << 5) +
         (u8(hdr.flevel) << 6)
     );
-    
+
     if (value % 31 == 0) {
         std::print("Zlib header checksum OK. Value: {}", value);
     } else {
@@ -65,12 +65,12 @@ fn validate_hdr_checksum(Header hdr) {
 struct Zlib {
     /// Configuration
     Header header;
-    
+
     if (header.fdict) {
         /// Adler checksum of the optional dictionary
         u32 dict;
     }
-    
+
     /// Compressed data
     u8 data[data_len];
     /// Adler-32 checksum of uncompressed data

--- a/tests/includes/source/main.cpp
+++ b/tests/includes/source/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
             return false;
         };
 
-        runtime.setDataSource(0x00, 0x100000, 
+        runtime.setDataSource(0x00, 0x100000,
             [&](pl::u64 address, pl::u8 *data, size_t size) {
                 pl::core::err::E0011.throwError("Include files should never read from memory directly!");
             }

--- a/tests/patterns/source/main.cpp
+++ b/tests/patterns/source/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
             return true;
         };
 
-        runtime.setDataSource(0x00, testFile.getSize(), 
+        runtime.setDataSource(0x00, testFile.getSize(),
             [&](pl::u64 address, pl::u8 *data, size_t size) {
                 testFile.seek(address);
                 testFile.readBuffer(data, size);
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
         runtime.addPragma("MIME", DummyPragmaHandler);
         runtime.addPragma("description", DescPragmaHandler);
         runtime.addDefine("__PL_UNIT_TESTS__");
-        
+
         runtime.setLogCallback([](auto level, const std::string &message) {
             switch (level) {
                 using enum pl::core::LogConsole::Level;

--- a/yara/advanced_analysis/language.yar
+++ b/yara/advanced_analysis/language.yar
@@ -6,7 +6,7 @@ rule LanguageCpp {
     strings:
         $exception_windows = "_CxxThrowException" ascii fullword
         $iostreams = "iostream" ascii
-        
+
     condition:
         any of them
 }


### PR DESCRIPTION
Hi,

I'm experimenting with using ImHex patterns outside of ImHex and have noticed a few formatting/style related quirks in the existing pattern files. In order to simplify my experiment's parser a bit I've adjusted some of the existing patterns.

The biggest change here is a commit that trims trailing whitespace project-wide. Let me know if I should drop this commit since it touches lots of files for unclear benefit. I'd recommend looking at the diff with [`&w=1`](https://github.com/WerWolv/ImHex-Patterns/pull/321/files?w=1) to collapse these.

Syntax quirks:
- Some files contain double semicolons. I've trimmed those.
- There's exactly one occurrence of a hex literal with upper case `X` in the JPEG pattern. I've replaced it with the common lower-case variant.
- The xgstexture pattern contains invalid syntax (`type::Magic"XGST">`). This was probably never noticed since the pattern doesn't have a unit test.

I've also included some slight functional changes that seemed sensible:
- check the header magic for ELF files
- check the file size field for the glTF pattern
- update deprecated CI actions

Feel free to merge or close. Thanks!