### PR TITLE
Fixed: Incorrect field on branch in bzip3

### DIFF
--- a/patterns/bzip3.hexpat
+++ b/patterns/bzip3.hexpat
@@ -47,7 +47,7 @@ struct Chunk {
     u32 compressedSize;   // Size of compressed block
     u32 origSize;         // Original uncompressed size
         
-    if (compressedSize < 64) {
+    if (origSize < 64) {
         SmallBlock block;
     } else {
         Block block;


### PR DESCRIPTION
Hi there.
Noticed a small thing, since I started fuzz testing bzip3 this morning.
Turns out I was branching on the wrong field; made an accidental error, because testing tiny files (< 64 bit) is rare.
Oopsie. In any case; this trivial fix should do it.