### PR TITLE
Fix parsing of signed leb128

### DIFF
--- a/includes/type/leb128.pat
+++ b/includes/type/leb128.pat
@@ -43,7 +43,7 @@ namespace auto type {
 
         fn transform_sleb128_array(ref auto array) {
             s128 res = type::impl::transform_uleb128_array(array);
-            if (res & 0x40 != 0) {
+            if (res & 1 << ((sizeof(array) / sizeof(u8)) * 7 - 1) != 0) {
                 res |= ~0 << (sizeof(array) / sizeof(u8)) * 7;
             }
             return res;


### PR DESCRIPTION
1. 0x80 0x40 is -8192 (-0x2000) in signed leb128, but the pattern language thinks it is 8192
2. 0xFF 0x3F is 8191 (0x1fff) in signed leb128, but the pattern language thinks it is -8193

The detection of the sign bit was wrong.