### PR TITLE
Add some improvements to the ISO pattern matching

### DIFF
--- a/patterns/iso.hexpat
+++ b/patterns/iso.hexpat
@@ -97,6 +97,10 @@ struct DirectoryRecord {
   u8 fileNameLen;
   char fileName[fileNameLen];
   padding[$ % 2];
+  u8 remainingSize = $ - addressof(this);
+  if (recordSize > remainingSize) {
+    u8 systemUse[recordSize - remainingSize];
+  }
 };
 
 fn GetSupplementaryEncoding() {

--- a/patterns/iso.hexpat
+++ b/patterns/iso.hexpat
@@ -99,6 +99,15 @@ struct DirectoryRecord {
   padding[$ % 2];
 };
 
+fn GetSupplementaryEncoding() {
+  const u128 escapeSequencesOffset = 89 - 8;
+
+  str encoding = std::mem::read_string($ + escapeSequencesOffset, 0x20);
+  return encoding == "%/@\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+      || encoding == "%/C\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+      || encoding == "%/E\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+};
+
 struct VolumeDescriptor {
   VolumeDescriptorTypes type;
   char id[5];
@@ -120,10 +129,38 @@ struct VolumeDescriptor {
     char setId[0x80];
     char publisherId[0x80];
     char preparerId[0x80];
-    char applicationId[0x80];
+  } else if (type == VolumeDescriptorTypes::SupplementaryVolume && GetSupplementaryEncoding()) {
     char copyrightFileId[0x25];
     char abstractFileId[0x25];
     char bibliographicFileId[0x25];
+    StrDateFormat creationTime[[format("FormatStrDate")]];
+    StrDateFormat modificationTime[[format("FormatStrDate")]];
+    StrDateFormat expirationTime[[format("FormatStrDate")]];
+    StrDateFormat effectiveTime[[format("FormatStrDate")]];
+    u8 fileStructVersion;
+  } else if (type == VolumeDescriptorTypes::SupplementaryVolume) {
+    u8 flags;
+    be char16 systemId[0x10];
+    be char16 volumeId[0x10];
+    padding[8];
+    di32 spaceSize;
+    u8 escapeSequences[0x20];
+    di16 setSize;
+    di16 sequenceNumber;
+    di16 logicalBlockSize;
+    di32 pathTableSize;
+    PathTablePtr pathTableOffset;
+    DirectoryRecord rootDir;
+    be char16 setId[0x40];
+    be char16 publisherId[0x40];
+    be char16 preparerId[0x40];
+    be char16 applicationId[0x40];
+    be char16 copyrightFileId[0x12];
+    padding[1];
+    be char16 abstractFileId[0x12];
+    padding[1];
+    be char16 bibliographicFileId[0x12];
+    padding[1];
     StrDateFormat creationTime[[format("FormatStrDate")]];
     StrDateFormat modificationTime[[format("FormatStrDate")]];
     StrDateFormat expirationTime[[format("FormatStrDate")]];

--- a/patterns/iso.hexpat
+++ b/patterns/iso.hexpat
@@ -4,6 +4,7 @@
 #pragma endian little
 
 import std.io;
+import std.mem;
 
 enum VolumeDescriptorTypes : u8 {
   BootRecord,
@@ -128,8 +129,9 @@ struct VolumeDescriptor {
     StrDateFormat expirationTime[[format("FormatStrDate")]];
     StrDateFormat effectiveTime[[format("FormatStrDate")]];
     u8 fileStructVersion;
-    padding[0x200 + 0x28E];
   }
+  padding[0x800 - $ % 0x800];
 };
 
-VolumeDescriptor data @ 0x8000;
+VolumeDescriptor descriptors[while(std::mem::read_unsigned($, 1) != 0xFF)] @ 0x8000;
+VolumeDescriptor terminator @ $;


### PR DESCRIPTION
Primarily it parses all volume descriptors and not just the first one. To do that it always allocates enough padding to reach a length of 2 KiB.

I also tried adding support for the supplementary volume descriptors assuming that it is using Joliet. I'm not sure if that second part fits the code quality of this repository and I can separate it into another pull request if requested: It might contain other encodings depending in the contents of the escape sequences.