### PR TITLE
fix: fixes issue #348

### DIFF
--- a/patterns/xbeh.hexpat
+++ b/patterns/xbeh.hexpat
@@ -329,7 +329,7 @@ fn relative_to_base(auto pointer) {
 };
 
 fn relative_to_base_section(auto pointer) {
-    return -parent.parent.baseAddress;
+    return -parent.parent.parent.baseAddress;
 };
 
 bitfield LibraryFlags {


### PR DESCRIPTION
In issue #348 it is stated that the pattern fails to find the variable baseAddress in the parent of the parent of the attribute function. One parent is required to access the variables on the pattern that is using the attribute.

That pattern is used in the pattern that contains baseAddress as a pointer to an array of the children pattern and that seems to require an extra parent level to be added in order to access baseAddress without errors. The fix was tested on an xbe file extracted from an xbox cd rom and while it failed without the fix as stated in issue 348 with the fix it ran to completion without issues.