### PR TITLE
patterns/zip: Handling padded extra fields

### DIFF
--- a/patterns/zip.hexpat
+++ b/patterns/zip.hexpat
@@ -192,7 +192,7 @@ struct LocalFileHeader {
     char fileName[fileNameLength] [[ comment("File Name") ]];
     u64 extraEnd = $ + extraFieldLength;
     extra::ExtraField extraFields[while (extra::has_extra_field(extraEnd))] [[comment("Extra Fields")]];
-    char unresolvedExtraFields[extraEnd - $];
+    padding[extraEnd - $];
     u8 data[compressedSize] [[name("File Data")]];
 };
 
@@ -222,7 +222,7 @@ struct CentralDirectoryFileHeader {
     char fileName[fileNameLength];
     u64 extraEnd = $ + extraFieldLength;
     extra::ExtraField extraFields[while (extra::has_extra_field(extraEnd))] [[comment("Extra Fields")]];
-    char unresolvedExtraFields[extraEnd - $];
+    padding[extraEnd - $];
     char comment[fileCommentLength] @ extraEnd;
 };
 

--- a/patterns/zip.hexpat
+++ b/patterns/zip.hexpat
@@ -90,9 +90,10 @@ namespace extra {
     };
     
     fn has_supported_extra_field(u32 extraEnd) {
+        if ($ + 4 > extraEnd) return false;
         u16 tag = std::mem::read_unsigned($, 2, std::mem::Endian::Little);
-        u16 len = std::mem::read_unsigned($, 2, std::mem::Endian::Little);
-        return $ + len < extraEnd && (tag == 0x5455 || tag == 0x000a || tag == 0x7875 || tag == 0x5855);
+        u16 len = std::mem::read_unsigned($ + 2, 2, std::mem::Endian::Little);
+        return $ + 4 + len <= extraEnd && (tag == 0x5455 || tag == 0x000a || tag == 0x7875 || tag == 0x5855);
     };
 }
 
@@ -190,7 +191,7 @@ struct LocalFileHeader {
     u16 extraFieldLength [[ comment("Extra field length (m)") ]];
     char fileName[fileNameLength] [[ comment("File Name") ]];
     u64 extraEnd = $ + extraFieldLength;
-    extra::ExtraField extraFields[while ($ < extraEnd && extra::has_supported_extra_field(extraEnd))] [[comment("Extra Fields")]];
+    extra::ExtraField extraFields[while (extra::has_supported_extra_field(extraEnd))] [[comment("Extra Fields")]];
     char unresolvedExtraFields[extraEnd - $];
     u8 data[compressedSize] [[name("File Data")]];
 };
@@ -220,7 +221,7 @@ struct CentralDirectoryFileHeader {
     File file;
     char fileName[fileNameLength];
     u64 extraEnd = $ + extraFieldLength;
-    extra::ExtraField extraFields[while ($ < extraEnd && extra::has_supported_extra_field(extraEnd))] [[comment("Extra Fields")]];
+    extra::ExtraField extraFields[while (extra::has_supported_extra_field(extraEnd))] [[comment("Extra Fields")]];
     char unresolvedExtraFields[extraEnd - $];
     char comment[fileCommentLength] @ extraEnd;
 };

--- a/patterns/zip.hexpat
+++ b/patterns/zip.hexpat
@@ -89,11 +89,11 @@ namespace extra {
         }
     };
     
-    fn has_supported_extra_field(u32 extraEnd) {
+    fn has_extra_field(u32 extraEnd) {
         if ($ + 4 > extraEnd) return false;
         u16 tag = std::mem::read_unsigned($, 2, std::mem::Endian::Little);
         u16 len = std::mem::read_unsigned($ + 2, 2, std::mem::Endian::Little);
-        return $ + 4 + len <= extraEnd && (tag == 0x5455 || tag == 0x000a || tag == 0x7875 || tag == 0x5855);
+        return !(tag == 0 || len == 0) && $ + 4 + len <= extraEnd;
     };
 }
 
@@ -191,7 +191,7 @@ struct LocalFileHeader {
     u16 extraFieldLength [[ comment("Extra field length (m)") ]];
     char fileName[fileNameLength] [[ comment("File Name") ]];
     u64 extraEnd = $ + extraFieldLength;
-    extra::ExtraField extraFields[while (extra::has_supported_extra_field(extraEnd))] [[comment("Extra Fields")]];
+    extra::ExtraField extraFields[while (extra::has_extra_field(extraEnd))] [[comment("Extra Fields")]];
     char unresolvedExtraFields[extraEnd - $];
     u8 data[compressedSize] [[name("File Data")]];
 };
@@ -221,7 +221,7 @@ struct CentralDirectoryFileHeader {
     File file;
     char fileName[fileNameLength];
     u64 extraEnd = $ + extraFieldLength;
-    extra::ExtraField extraFields[while (extra::has_supported_extra_field(extraEnd))] [[comment("Extra Fields")]];
+    extra::ExtraField extraFields[while (extra::has_extra_field(extraEnd))] [[comment("Extra Fields")]];
     char unresolvedExtraFields[extraEnd - $];
     char comment[fileCommentLength] @ extraEnd;
 };

--- a/patterns/zip.hexpat
+++ b/patterns/zip.hexpat
@@ -75,18 +75,24 @@ namespace extra {
     struct ExtraField {
         u16 tag;
         u16 TSize;
-        if (tag == 0x5455){
+        if (tag == 0x5455) {
             extra::X5455_ExtendedTimestamp x5455_ExtendedTimestamp;
-        }else if (tag == 0x000a){
+        } else if (tag == 0x000a) {
             extra::X000A_NTFS x000A_NTFS;
-        }else if (tag == 0x7875){
+        } else if (tag == 0x7875) {
             extra::X7875_NewUnix x7875_NewUnix;
-        }else if (tag == 0x5855){
+        } else if (tag == 0x5855) {
             extra::X5855_InfoZipUnix x5855_InfoZipUnix;
-        }else{
+        } else {
             std::print("Unsupported tag 0x{:02X}", tag);
             padding[TSize];
         }
+    };
+    
+    fn has_supported_extra_field(u32 extraEnd) {
+        u16 tag = std::mem::read_unsigned($, 2, std::mem::Endian::Little);
+        u16 len = std::mem::read_unsigned($, 2, std::mem::Endian::Little);
+        return $ + len < extraEnd && (tag == 0x5455 || tag == 0x000a || tag == 0x7875 || tag == 0x5855);
     };
 }
 
@@ -184,7 +190,8 @@ struct LocalFileHeader {
     u16 extraFieldLength [[ comment("Extra field length (m)") ]];
     char fileName[fileNameLength] [[ comment("File Name") ]];
     u64 extraEnd = $ + extraFieldLength;
-    extra::ExtraField extraFields[while ($ < extraEnd)] [[comment("Extra Fields")]];
+    extra::ExtraField extraFields[while ($ < extraEnd && extra::has_supported_extra_field(extraEnd))] [[comment("Extra Fields")]];
+    char unresolvedExtraFields[extraEnd - $];
     u8 data[compressedSize] [[name("File Data")]];
 };
 
@@ -213,8 +220,9 @@ struct CentralDirectoryFileHeader {
     File file;
     char fileName[fileNameLength];
     u64 extraEnd = $ + extraFieldLength;
-    extra::ExtraField extraFields[while ($ < extraEnd)] [[comment("Extra Fields")]];
-    char comment[fileCommentLength];
+    extra::ExtraField extraFields[while ($ < extraEnd && extra::has_supported_extra_field(extraEnd))] [[comment("Extra Fields")]];
+    char unresolvedExtraFields[extraEnd - $];
+    char comment[fileCommentLength] @ extraEnd;
 };
 
 CentralDirectoryFileHeader centralDirHeaders[fileInfo.CDRCount] @ (fileInfo.CDOffset) [[name("Files")]];


### PR DESCRIPTION
Some zip files have their extra fields padded at the end  (such as apks processed by [zipalign](https://cs.android.com/android/platform/superproject/main/+/main:build/make/tools/zipalign/ZipEntry.cpp;l=210;drc=9c843a66d11d85e1f69e944f1b37314d3e47aab1))