### PR TITLE
Add magic number for UF2 pattern

### DIFF
--- a/patterns/uf2.hexpat
+++ b/patterns/uf2.hexpat
@@ -1,5 +1,6 @@
 #pragma author WerWolv
 #pragma description USB Flashing Format (.uf2)
+#pragma magic [ 55 46 32 0A 57 51 5D 9E ] @ 0x00
 
 import std.sys;
 import std.mem;


### PR DESCRIPTION
Adds a `#pragma magic` from the [spec](https://github.com/microsoft/uf2#file-format) so UF2 files can be auto-detected. 


<img width="442" alt="Screenshot 2025-03-31 at 3 06 06 PM" src="https://github.com/user-attachments/assets/a9c25d73-d99d-497f-9570-faf7601655b3" />
