### PR TITLE
Removed alpha from color attribute

### DIFF
--- a/includes/type/color.pat
+++ b/includes/type/color.pat
@@ -21,7 +21,7 @@ namespace auto type {
         g : G;
         b : B;
         if (A > 0) a : A;
-    } [[sealed, format("type::impl::format_color"), color(std::format("{0:02X}{1:02X}{2:02X}FF", r, g, b))]];
+    } [[sealed, format("type::impl::format_color"), color(std::format("{0:02X}{1:02X}{2:02X}", r, g, b))]];
 
     /**
         Type representing a generic RGB color with a variable number of bits for each color


### PR DESCRIPTION
The color attribute does not nclude an alpha component but the RGB types were including an alpha of 255 making all colors bluish.