### PR TITLE
pattern wintec_tes: slightly nicer formatting in a list of entries

### DIFF
--- a/patterns/wintec_tes.hexpat
+++ b/patterns/wintec_tes.hexpat
@@ -24,6 +24,7 @@
 #include "std/mem.pat"
 #include "std/string.pat"
 
+using WBTLine;
 using WBTTimestamp;
 
 // helper to format latitude and longitude in a human-readable form
@@ -42,6 +43,11 @@ fn iso8601(WBTTimestamp input) {
     return std::format("20{:02d}-{:02d}-{:02d}T{:02d}:{:02d}:{:02d}Z",input.year, input.month, input.day, input.hours, input.minutes, input.seconds);
 };
 
+
+// short format for overview in a list
+fn shortString(WBTLine input) {
+    return std::format("{:02d}:{:02d}:{:02d} {:s},{:s}", input.timestamp.hours, input.timestamp.minutes, input.timestamp.seconds, stringDegrees(input.lat), stringDegrees(input.lon));
+};
 
 // This 16 bit field is barely used. Only these two are known.
 bitfield WBTFlags {
@@ -70,7 +76,7 @@ struct WBTLine {
     s32 lat [[color("007FFF"), format("stringDegrees")]];
     s32 lon [[color("7F00FF"), format("stringDegrees")]];
     s16 alt [[color("0000FF")]];
-} [[hex::visualize("coordinates", decimalDegrees(lat), decimalDegrees(lon))]];
+} [[hex::visualize("coordinates", decimalDegrees(lat), decimalDegrees(lon)), format("shortString")]];
 
 
 // parsing that whole file start to finish:


### PR DESCRIPTION
When viewing a wintec file, it typically consists of hundreds of entries line by line. I found out that any entry can be formatted, so the lines themselves now also get a readable string. This now looks like this:

![image](https://github.com/user-attachments/assets/680c4c31-9998-4caa-92fb-9ba735ae7907)

(it used to display just `{ ... }` in the Value-column)