### PR TITLE
Add support for medium and large mp4 files

### DIFF
--- a/patterns/mp4.hexpat
+++ b/patterns/mp4.hexpat
@@ -424,7 +424,7 @@ struct MovieBox : BaseBox {
 };
 
 struct MediaDataBox : BaseBox {
-    u8 data[while($ < endOffset)] [[sealed]];
+    std::mem::Bytes<boxSize - sizeof(size) - sizeof(type)> data;
 };
 
 struct Box {


### PR DESCRIPTION
The current implementation of mp4-pattern is very slow to deal with any larger mp4 files. Even loading a 50 megabyte mp4 video file is very slow and takes many minutes on a modern computer

The problem is the "mdat"  or MediaData box which is the biggest box contaning the raw media data have a very to slow implementation in the mp4-pattern language file.

This PR replaces the "mdat" box implementation with a much faster one, that so that we can work with files gigabytes in size instead of just 50 megabytes before everything gets way to slow

## Verify the speed improvement from this PR
Here is an example mp4 file of 270 megbyte
https://www.peach.themazzone.com/durian/movies/sintel-2048-surround.mp4
(found [here](https://durian.blender.org/download/))

Open it with the existing mp4-pattern. It take many minutes to open, if it manages to open at all.

Change to the implementation of mp4-pattern in this PR. The same file can now be opened in seconds.