### PR TITLE
fix: issues with two remaining themes.

### DIFF
--- a/themes/Nocturne.json
+++ b/themes/Nocturne.json
@@ -1,6 +1,6 @@
 {
-    "base": "Nocturne (Dark)",
-    "name": "Nocture",
+    "base": "Dark",
+    "name": "Nocturne",
     "image_theme": "dark",
     "authors": "JeanxPereira",
     "description": "minimal dark theme based on Dracula but more darker",
@@ -162,7 +162,7 @@
             "default": "#7F7F7FFF",
             "doc-comment": "#206020FF",
             "error-marker": "#D83545FF",
-            "global-doc-comment": "#2B9C89FF",
+            "doc-global-comment": "#2B9C89FF",
             "identifier": "#AFAFAFFF",
             "keyword": "#F87AC4FF",
             "known-identifier": "#6CF982FF",

--- a/themes/one_dark.json
+++ b/themes/one_dark.json
@@ -158,7 +158,7 @@
             "default": "#DADADAFF",
             "doc-comment": "#206858FF",
             "error-marker": "#C01A2BFF",
-            "global-doc-comment": "#208070FF",
+            "doc-global-comment": "#208070FF",
             "identifier": "#E4E4E4FB",
             "keyword": "#C46DE6FF",
             "known-identifier": "#C46DE6FF",


### PR DESCRIPTION
Both one-dark and nocturne used global-doc-comment instead of the correctly named doc-global-comment. Typos in Nocturned didn't prevent the theme from loading, but left annoying messages in the log. As explained by the author, the base colormap must be one of the three that imhex loads by default, dark,light and/or classic.