### PR TITLE
Fix ext4 pattern group descriptor table location for non-1024 block sizes

### DIFF
--- a/patterns/fs/ext4.hexpat
+++ b/patterns/fs/ext4.hexpat
@@ -540,4 +540,4 @@ struct ext4_group_descriptors {
     }
 };
 
-ext4_group_descriptors group_descs @ block_to_address(2);
+ext4_group_descriptors group_descs @ block_to_address(super_block.s_first_data_block + 1);


### PR DESCRIPTION
When `s_first_data_block` is 1, the table is located at block 2 (how it was hard-coded before), but when `s_first_data_block` is 0, the table is at block 1.

This caused the the pattern parsing to fail on file systems with non-1024 sized blocks.