### PR TITLE
Create Agilent/Rigol pattern waveform parser

### DIFF
--- a/patterns/wavebin.hexpat
+++ b/patterns/wavebin.hexpat
@@ -1,6 +1,8 @@
-#pragma pattern_name Agilent/Rigol Waveform
+#pragma author kenkit
+#pragma description Agilent/Rigol Waveform
 #pragma file_extension bin
 #pragma magic [ 41 47, 52 47 ] @ 0x00 // Matches "AG" or "RG" at offset 0
+
 
 #include <std/mem.pat>
 


### PR DESCRIPTION
feat(patterns): add Agilent/Rigol wavebin waveform parser

Adds a new Pattern Language script to parse `.bin` waveform files exported from Agilent, Keysight, and Rigol oscilloscopes.

Features:
- Supports File Header versions 1, 3, and 10.
- Parses nested Waveform and Data headers.
- Automatically handles variable-length data buffers (float32 and u8).
- Includes auto-load pragmas for magic bytes 'AG' and 'RG'.
- Organizes sample data into inspectable arrays in the Pattern Data view.

Based on https://github.com/sam210723/wavebin/