### PR TITLE
Add Unity Web Data 1.0 pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Everything will immediately show up in ImHex's Content Store and gets bundled wi
 | UEFI Variable Store | | [`patterns/uefi_fv_varstore.hexpat`](patterns/uefi_fv_varstore.hexpat) | UEFI Firmware Volume Variable Store |
 | UF2 | | [`patterns/uf2.hexpat`](patterns/uf2.hexpat) | [USB Flashing Format](https://github.com/microsoft/uf2) |
 | Unity Asset Bundle | | [`patterns/unity-asset-bundle.hexpat`](patterns/unity-asset-bundle.hexpat) | Unity Asset Bundle |
+| Unity Web Data 1.0 | | [`patterns/unity_web_data.hexpat`](patterns/unity_web_data.hexpat) | Unity Web Data 1.0 |
 | Valve VPK | | [`patterns/valve_vpk.hexpat`](valve_vpk.hexpat) | Valve Package File |
 | VBMeta | | [`patterns/vbmeta.hexpat`](patterns/vbmeta.hexpat) | Android VBMeta image |
 | VDF | | [`patterns/vdf.hexpat`](patterns/vdf.hexpat) | Binary Value Data Format (.vdf) files |

--- a/patterns/unity_web_data.hexpat
+++ b/patterns/unity_web_data.hexpat
@@ -1,0 +1,25 @@
+#pragma author unidentifiedfox
+#pragma description Unity Web Data 1.0
+
+#pragma magic ["UnityWebData1.0\0"] @ 0x00
+#pragma endian little
+
+import std.mem;
+
+struct FileEntry {
+    u32 fileOffset;
+    u32 fileSize;
+    u32 filePathSize;
+    char filePath[filePathSize];
+
+    std::mem::Bytes<fileSize> fileData @ fileOffset [[name(filePath)]];
+};
+
+struct Header {
+    char signature[16];
+    u32 headerSize;
+
+    FileEntry entries[while($ < headerSize)];
+};
+
+Header header @ 0x00;


### PR DESCRIPTION
Added a pattern for Unity Web Data 1.0 files, used in Unity WebGL games for storing assets and metadata.