### PR TITLE
patterns/elf: Fix off by 1 error in shdr payload size checking

### DIFF
--- a/patterns/elf.hexpat
+++ b/patterns/elf.hexpat
@@ -676,7 +676,7 @@ struct Elf32_Shdr {
     Elf32_Word sh_addralign;
     Elf32_Word sh_entsize;
 
-    if (sh_size > 0 && sh_offset + sh_size < std::mem::size()) {
+    if (sh_size > 0 && sh_offset + sh_size <= std::mem::size()) {
     	if (sh_type == SHT::NOBITS || sh_type == SHT::NULL) {
 		// Section has no data
 		} else if (sh_type == SHT::STRTAB) {
@@ -751,7 +751,7 @@ struct Elf64_Shdr {
     Elf64_Xword sh_addralign;
     Elf64_Xword sh_entsize;
 
-    if (sh_size > 0 && sh_offset + sh_size < std::mem::size()) {
+    if (sh_size > 0 && sh_offset + sh_size <= std::mem::size()) {
     	if (sh_type == SHT::NOBITS || sh_type == SHT::NULL) {
 			// Section has no data
 		} else if (sh_type == SHT::STRTAB) {


### PR DESCRIPTION
The old check `sh_offset + sh_size < std::mem::size()` fails when the payload ends just before EOF. This can happen for hand-crafted files when `shdr` is not at the end.