### PR TITLE
fix: make fmod take the correct amount of parameters

### DIFF
--- a/includes/std/math.pat
+++ b/includes/std/math.pat
@@ -183,11 +183,12 @@ namespace auto std::math {
     fn ln(auto value) { return builtin::std::math::ln(value); };
 
     /**
-        Calculates the floating point modulus of `value`.
-        @param value Value
-        @return Floating point modulus of `value`
+        Calculates the floating point modulus (remainder) of the division of `x` by `y`.
+        @param x Numerator
+        @param y Denominator
+        @return Floating point modulus (remainder) of the division of `x` by `y`
     */
-    fn fmod(auto value) { return builtin::std::math::fmod(value); };
+    fn fmod(auto x, auto y) { return builtin::std::math::fmod(x, y); };
 
     /**
         Calculates the value of `base` raised to the power of `exp`.


### PR DESCRIPTION
The previous version of the std::math::fmod function only took one argument which was incorrect and rendered the function impossible to use.

This patch fixes this issue by making the std::math::fmod function take 2 arguments (numerator and denominator) so the remainder of the division can be effectively calculated.