### PR TITLE
disassemblers: add lua 5.0 through 5.5

### DIFF
--- a/disassemblers/lua50.json
+++ b/disassemblers/lua50.json
@@ -1,0 +1,322 @@
+{
+  "name": "Lua5.1",
+  "includes": [],
+  "prefixes": [],
+  "opcodes": [
+    {
+      "mnemonic": "move",
+      "format": "",
+      "mask": "AA00'0000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "loadk",
+      "format": "",
+      "mask": "AA00'0001 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R(A) := Kst(Bx)",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "loadbool",
+      "format": "",
+      "mask": "AA00'0010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := (Bool)B; if (C) PC++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "loadnil",
+      "format": "",
+      "mask": "AA00'0011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := ... := R(B) := nil",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "getupval",
+      "format": "",
+      "mask": "AA00'0100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := UpValue[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "getglobal",
+      "format": "",
+      "mask": "AA00'0101 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R(A) := Gbl[Kst(Bx)]",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "gettable",
+      "format": "",
+      "mask": "AA00'0110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := R(B)[RK(C)]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "setglobal",
+      "format": "",
+      "mask": "AA00'0111 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx Gbl[Kst(Bx)] := R(A)",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "setupval",
+      "format": "",
+      "mask": "AA00'1000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B UpValue[B] := R(A)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "settable",
+      "format": "",
+      "mask": "AA00'1001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A)[RK(B)] := RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "newtable",
+      "format": "",
+      "mask": "AA00'1010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := {} (size = B,C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "self",
+      "format": "",
+      "mask": "AA00'1011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A+1) := R(B); R(A) := R(B)[RK(C)]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "add",
+      "format": "",
+      "mask": "AA00'1100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) + RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "sub",
+      "format": "",
+      "mask": "AA00'1101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) - RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mul",
+      "format": "",
+      "mask": "AA00'1110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) * RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "div",
+      "format": "",
+      "mask": "AA00'1111 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) / RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "pow",
+      "format": "",
+      "mask": "AA01'0000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) ^ RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "unm",
+      "format": "",
+      "mask": "AA01'0001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := -R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "not",
+      "format": "",
+      "mask": "AA01'0010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := not R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "concat",
+      "format": "",
+      "mask": "AA01'0011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := R(B).. ... ..R(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "jmp",
+      "format": "",
+      "mask": "AA01'0100 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "sBx PC += sBx",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "eq",
+      "format": "",
+      "mask": "AA01'0101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if ((RK(B) == RK(C)) ~= A) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "lt",
+      "format": "",
+      "mask": "AA01'0110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if ((RK(B) < RK(C)) ~= A) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "le",
+      "format": "",
+      "mask": "AA01'0111 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if ((RK(B) <= RK(C)) ~= A) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "test",
+      "format": "",
+      "mask": "AA01'1000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if (R(B) <=> C) then R(A) := R(B) else pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "call",
+      "format": "",
+      "mask": "AA01'1001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A), ... ,R(A+C-2) := R(A)(R(A+1), ... ,R(A+B-1))",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "tailcall",
+      "format": "",
+      "mask": "AA01'1010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C return R(A)(R(A+1), ... ,R(A+B-1))",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "return",
+      "format": "",
+      "mask": "AA01'1011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B return R(A), ... ,R(A+B-2) (see note)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "forloop",
+      "format": "",
+      "mask": "AA01'1100 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx R(A)+=R(A+2); if R(A) <?= R(A+1) then PC+= sBx",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "tforloop",
+      "format": "",
+      "mask": "AA01'1101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A C R(A+2), ... ,R(A+2+C) := R(A)(R(A+1), R(A+2)); if R(A+2) ~= nil then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "tforprep",
+      "format": "",
+      "mask": "AA01'1110 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx if type(R(A)) == table then R(A+1):=R(A), R(A):=next; PC += sBx",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "setlist",
+      "format": "",
+      "mask": "AA01'1111 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R(A)[Bx-Bx%FPF+i] := R(A+i), 1 <= i <= Bx%FPF+1",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "setlisto",
+      "format": "",
+      "mask": "AA10'0000 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "close",
+      "format": "",
+      "mask": "AA10'0001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A close all variables in the stack up to (>=) R(A)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "closure",
+      "format": "",
+      "mask": "AA10'0010 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R(A) := closure(KPROTO[Bx], R(A), ... ,R(A+n))",
+        "opmode": "iABx"
+      }
+    }
+  ]
+}

--- a/disassemblers/lua51.json
+++ b/disassemblers/lua51.json
@@ -1,0 +1,349 @@
+{
+  "name": "Lua5.1",
+  "includes": [],
+  "prefixes": [],
+  "opcodes": [
+    {
+      "mnemonic": "move",
+      "format": "",
+      "mask": "AA00'0000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "loadk",
+      "format": "",
+      "mask": "AA00'0001 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R(A) := Kst(Bx)",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "loadbool",
+      "format": "",
+      "mask": "AA00'0010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := (Bool)B; if (C) pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "loadnil",
+      "format": "",
+      "mask": "AA00'0011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := ... := R(B) := nil",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "getupval",
+      "format": "",
+      "mask": "AA00'0100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := UpValue[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "getglobal",
+      "format": "",
+      "mask": "AA00'0101 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R(A) := Gbl[Kst(Bx)]",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "gettable",
+      "format": "",
+      "mask": "AA00'0110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := R(B)[RK(C)]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "setglobal",
+      "format": "",
+      "mask": "AA00'0111 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx Gbl[Kst(Bx)] := R(A)",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "setupval",
+      "format": "",
+      "mask": "AA00'1000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B UpValue[B] := R(A)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "settable",
+      "format": "",
+      "mask": "AA00'1001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A)[RK(B)] := RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "newtable",
+      "format": "",
+      "mask": "AA00'1010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := {} (size = B,C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "self",
+      "format": "",
+      "mask": "AA00'1011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A+1) := R(B); R(A) := R(B)[RK(C)]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "add",
+      "format": "",
+      "mask": "AA00'1100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) + RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "sub",
+      "format": "",
+      "mask": "AA00'1101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) - RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mul",
+      "format": "",
+      "mask": "AA00'1110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) * RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "div",
+      "format": "",
+      "mask": "AA00'1111 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) / RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mod",
+      "format": "",
+      "mask": "AA01'0000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) % RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "pow",
+      "format": "",
+      "mask": "AA01'0001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) ^ RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "unm",
+      "format": "",
+      "mask": "AA01'0010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := -R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "not",
+      "format": "",
+      "mask": "AA01'0011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := not R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "len",
+      "format": "",
+      "mask": "AA01'0100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := length of R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "concat",
+      "format": "",
+      "mask": "AA01'0101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := R(B).. ... ..R(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "jmp",
+      "format": "",
+      "mask": "AA01'0110 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "sBx pc+=sBx",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "eq",
+      "format": "",
+      "mask": "AA01'0111 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if ((RK(B) == RK(C)) ~= A) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "lt",
+      "format": "",
+      "mask": "AA01'1000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if ((RK(B) < RK(C)) ~= A) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "le",
+      "format": "",
+      "mask": "AA01'1001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if ((RK(B) <= RK(C)) ~= A) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "test",
+      "format": "",
+      "mask": "AA01'1010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A C if not (R(A) <=> C) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "testset",
+      "format": "",
+      "mask": "AA01'1011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if (R(B) <=> C) then R(A) := R(B) else pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "call",
+      "format": "",
+      "mask": "AA01'1100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A), ... ,R(A+C-2) := R(A)(R(A+1), ... ,R(A+B-1))",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "tailcall",
+      "format": "",
+      "mask": "AA01'1101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C return R(A)(R(A+1), ... ,R(A+B-1))",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "return",
+      "format": "",
+      "mask": "AA01'1110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B return R(A), ... ,R(A+B-2) (see note)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "forloop",
+      "format": "",
+      "mask": "AA01'1111 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx R(A)+=R(A+2); if R(A) <?= R(A+1) then { pc+=sBx; R(A+3)=R(A) }",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "forprep",
+      "format": "",
+      "mask": "AA10'0000 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx R(A)-=R(A+2); pc+=sBx",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "tforloop",
+      "format": "",
+      "mask": "AA10'0001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A C R(A+3), ... ,R(A+2+C) := R(A)(R(A+1), R(A+2)); if R(A+3) ~= nil then R(A+2)=R(A+3) else pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "setlist",
+      "format": "",
+      "mask": "AA10'0010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A)[(C-1)*FPF+i] := R(A+i), 1 <= i <= B",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "close",
+      "format": "",
+      "mask": "AA10'0011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A close all variables in the stack up to (>=) R(A)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "closure",
+      "format": "",
+      "mask": "AA10'0100 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R(A) := closure(KPROTO[Bx], R(A), ... ,R(A+n))",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "vararg",
+      "format": "",
+      "mask": "AA10'0101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A), R(A+1), ..., R(A+B-1) = vararg",
+        "opmode": "iABC"
+      }
+    }
+  ]
+}

--- a/disassemblers/lua52.json
+++ b/disassemblers/lua52.json
@@ -1,0 +1,367 @@
+{
+  "name": "Lua5.2",
+  "includes": [],
+  "prefixes": [],
+  "opcodes": [
+    {
+      "mnemonic": "move",
+      "format": "",
+      "mask": "AA00'0000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "loadk",
+      "format": "",
+      "mask": "AA00'0001 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R(A) := Kst(Bx)",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "loadkx",
+      "format": "",
+      "mask": "AA00'0010 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A R(A) := Kst(extra arg)",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "loadbool",
+      "format": "",
+      "mask": "AA00'0011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := (Bool)B; if (C) pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "loadnil",
+      "format": "",
+      "mask": "AA00'0100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A), R(A+1), ..., R(A+B) := nil",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "getupval",
+      "format": "",
+      "mask": "AA00'0101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := UpValue[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "gettabup",
+      "format": "",
+      "mask": "AA00'0110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := UpValue[B][RK(C)]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "gettable",
+      "format": "",
+      "mask": "AA00'0111 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := R(B)[RK(C)]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "settabup",
+      "format": "",
+      "mask": "AA00'1000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C UpValue[A][RK(B)] := RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "setupval",
+      "format": "",
+      "mask": "AA00'1001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B UpValue[B] := R(A)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "settable",
+      "format": "",
+      "mask": "AA00'1010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A)[RK(B)] := RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "newtable",
+      "format": "",
+      "mask": "AA00'1011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := {} (size = B,C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "self",
+      "format": "",
+      "mask": "AA00'1100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A+1) := R(B); R(A) := R(B)[RK(C)]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "add",
+      "format": "",
+      "mask": "AA00'1101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) + RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "sub",
+      "format": "",
+      "mask": "AA00'1110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) - RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mul",
+      "format": "",
+      "mask": "AA00'1111 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) * RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "div",
+      "format": "",
+      "mask": "AA01'0000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) / RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mod",
+      "format": "",
+      "mask": "AA01'0001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) % RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "pow",
+      "format": "",
+      "mask": "AA01'0010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) ^ RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "unm",
+      "format": "",
+      "mask": "AA01'0011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := -R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "not",
+      "format": "",
+      "mask": "AA01'0100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := not R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "len",
+      "format": "",
+      "mask": "AA01'0101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := length of R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "concat",
+      "format": "",
+      "mask": "AA01'0110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := R(B).. ... ..R(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "jmp",
+      "format": "",
+      "mask": "AA01'0111 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx pc+=sBx; if (A) close all upvalues >= R(A) + 1",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "eq",
+      "format": "",
+      "mask": "AA01'1000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if ((RK(B) == RK(C)) ~= A) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "lt",
+      "format": "",
+      "mask": "AA01'1001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if ((RK(B) < RK(C)) ~= A) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "le",
+      "format": "",
+      "mask": "AA01'1010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if ((RK(B) <= RK(C)) ~= A) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "test",
+      "format": "",
+      "mask": "AA01'1011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A C if not (R(A) <=> C) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "testset",
+      "format": "",
+      "mask": "AA01'1100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if (R(B) <=> C) then R(A) := R(B) else pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "call",
+      "format": "",
+      "mask": "AA01'1101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A), ... ,R(A+C-2) := R(A)(R(A+1), ... ,R(A+B-1))",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "tailcall",
+      "format": "",
+      "mask": "AA01'1110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C return R(A)(R(A+1), ... ,R(A+B-1))",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "return",
+      "format": "",
+      "mask": "AA01'1111 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B return R(A), ... ,R(A+B-2) (see note)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "forloop",
+      "format": "",
+      "mask": "AA10'0000 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx R(A)+=R(A+2); if R(A) <?= R(A+1) then { pc+=sBx; R(A+3)=R(A) }",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "forprep",
+      "format": "",
+      "mask": "AA10'0001 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx R(A)-=R(A+2); pc+=sBx",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "tforcall",
+      "format": "",
+      "mask": "AA10'0010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A C R(A+3), ... ,R(A+2+C) := R(A)(R(A+1), R(A+2));",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "tforloop",
+      "format": "",
+      "mask": "AA10'0011 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx if R(A+1) ~= nil then { R(A)=R(A+1); pc += sBx }",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "setlist",
+      "format": "",
+      "mask": "AA10'0100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A)[(C-1)*FPF+i] := R(A+i), 1 <= i <= B",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "closure",
+      "format": "",
+      "mask": "AA10'0101 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R(A) := closure(KPROTO[Bx])",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "vararg",
+      "format": "",
+      "mask": "AA10'0110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A), R(A+1), ..., R(A+B-2) = vararg",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "extraarg",
+      "format": "",
+      "mask": "AA10'0111 AAAA'AAAA AAAA'AAAA AAAA'AAAA",
+      "metadata": {
+        "comment": "Ax extra (larger) argument for previous opcode",
+        "opmode": "iAx"
+      }
+    }
+  ]
+}

--- a/disassemblers/lua53.json
+++ b/disassemblers/lua53.json
@@ -1,0 +1,430 @@
+{
+  "name": "Lua5.3",
+  "includes": [],
+  "prefixes": [],
+  "opcodes": [
+    {
+      "mnemonic": "move",
+      "format": "",
+      "mask": "AA00'0000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "loadk",
+      "format": "",
+      "mask": "AA00'0001 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R(A) := Kst(Bx)",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "loadkx",
+      "format": "",
+      "mask": "AA00'0010 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A R(A) := Kst(extra arg)",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "loadbool",
+      "format": "",
+      "mask": "AA00'0011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := (Bool)B; if (C) pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "loadnil",
+      "format": "",
+      "mask": "AA00'0100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A), R(A+1), ..., R(A+B) := nil",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "getupval",
+      "format": "",
+      "mask": "AA00'0101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := UpValue[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "gettabup",
+      "format": "",
+      "mask": "AA00'0110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := UpValue[B][RK(C)]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "gettable",
+      "format": "",
+      "mask": "AA00'0111 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := R(B)[RK(C)]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "settabup",
+      "format": "",
+      "mask": "AA00'1000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C UpValue[A][RK(B)] := RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "setupval",
+      "format": "",
+      "mask": "AA00'1001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B UpValue[B] := R(A)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "settable",
+      "format": "",
+      "mask": "AA00'1010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A)[RK(B)] := RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "newtable",
+      "format": "",
+      "mask": "AA00'1011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := {} (size = B,C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "self",
+      "format": "",
+      "mask": "AA00'1100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A+1) := R(B); R(A) := R(B)[RK(C)]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "add",
+      "format": "",
+      "mask": "AA00'1101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) + RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "sub",
+      "format": "",
+      "mask": "AA00'1110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) - RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mul",
+      "format": "",
+      "mask": "AA00'1111 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) * RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mod",
+      "format": "",
+      "mask": "AA01'0000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) % RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "pow",
+      "format": "",
+      "mask": "AA01'0001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) ^ RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "div",
+      "format": "",
+      "mask": "AA01'0010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) / RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "idiv",
+      "format": "",
+      "mask": "AA01'0011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) // RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "band",
+      "format": "",
+      "mask": "AA01'0100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) & RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bor",
+      "format": "",
+      "mask": "AA01'0101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) | RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bxor",
+      "format": "",
+      "mask": "AA01'0110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) ~ RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "shl",
+      "format": "",
+      "mask": "AA01'0111 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) << RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "shr",
+      "format": "",
+      "mask": "AA01'1000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := RK(B) >> RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "unm",
+      "format": "",
+      "mask": "AA01'1001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := -R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bnot",
+      "format": "",
+      "mask": "AA01'1010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := ~R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "not",
+      "format": "",
+      "mask": "AA01'1011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := not R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "len",
+      "format": "",
+      "mask": "AA01'1100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A) := length of R(B)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "concat",
+      "format": "",
+      "mask": "AA01'1101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A) := R(B).. ... ..R(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "jmp",
+      "format": "",
+      "mask": "AA01'1110 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx pc+=sBx; if (A) close all upvalues >= R(A - 1)",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "eq",
+      "format": "",
+      "mask": "AA01'1111 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if ((RK(B) == RK(C)) ~= A) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "lt",
+      "format": "",
+      "mask": "AA10'0000 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if ((RK(B) < RK(C)) ~= A) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "le",
+      "format": "",
+      "mask": "AA10'0001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if ((RK(B) <= RK(C)) ~= A) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "test",
+      "format": "",
+      "mask": "AA10'0010 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A C if not (R(A) <=> C) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "testset",
+      "format": "",
+      "mask": "AA10'0011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C if (R(B) <=> C) then R(A) := R(B) else pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "call",
+      "format": "",
+      "mask": "AA10'0100 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A), ... ,R(A+C-2) := R(A)(R(A+1), ... ,R(A+B-1))",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "tailcall",
+      "format": "",
+      "mask": "AA10'0101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C return R(A)(R(A+1), ... ,R(A+B-1))",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "return",
+      "format": "",
+      "mask": "AA10'0110 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B return R(A), ... ,R(A+B-2) (see note)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "forloop",
+      "format": "",
+      "mask": "AA10'0111 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx R(A)+=R(A+2); if R(A) <?= R(A+1) then { pc+=sBx; R(A+3)=R(A) }",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "forprep",
+      "format": "",
+      "mask": "AA10'1000 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx R(A)-=R(A+2); pc+=sBx",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "tforcall",
+      "format": "",
+      "mask": "AA10'1001 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A C R(A+3), ... ,R(A+2+C) := R(A)(R(A+1), R(A+2));",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "tforloop",
+      "format": "",
+      "mask": "AA10'1010 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx if R(A+1) ~= nil then { R(A)=R(A+1); pc += sBx }",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "setlist",
+      "format": "",
+      "mask": "AA10'1011 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R(A)[(C-1)*FPF+i] := R(A+i), 1 <= i <= B",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "closure",
+      "format": "",
+      "mask": "AA10'1100 BBAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R(A) := closure(KPROTO[Bx])",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "vararg",
+      "format": "",
+      "mask": "AA10'1101 BBAA'AAAA CBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R(A), R(A+1), ..., R(A+B-2) = vararg",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "extraarg",
+      "format": "",
+      "mask": "AA10'1110 AAAA'AAAA AAAA'AAAA AAAA'AAAA",
+      "metadata": {
+        "comment": "Ax extra (larger) argument for previous opcode",
+        "opmode": "iAx"
+      }
+    }
+  ]
+}

--- a/disassemblers/lua54.json
+++ b/disassemblers/lua54.json
@@ -1,0 +1,754 @@
+{
+  "name": "Lua5.4",
+  "includes": [],
+  "prefixes": [],
+  "opcodes": [
+    {
+      "mnemonic": "move",
+      "format": "",
+      "mask": "A000'0000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A] := R[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "loadi",
+      "format": "",
+      "mask": "A000'0001 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx R[A] := sBx",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "loadf",
+      "format": "",
+      "mask": "A000'0010 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx R[A] := (lua_Number)sBx",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "loadk",
+      "format": "",
+      "mask": "A000'0011 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R[A] := K[Bx]",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "loadkx",
+      "format": "",
+      "mask": "A000'0100 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A R[A] := K[extra arg]",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "loadfalse",
+      "format": "",
+      "mask": "A000'0101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A R[A] := false",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "lfalseskip",
+      "format": "",
+      "mask": "A000'0110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A R[A] := false; pc++ (*)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "loadtrue",
+      "format": "",
+      "mask": "A000'0111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A R[A] := true",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "loadnil",
+      "format": "",
+      "mask": "A000'1000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A], R[A+1], ..., R[A+B] := nil",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "getupval",
+      "format": "",
+      "mask": "A000'1001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A] := UpValue[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "setupval",
+      "format": "",
+      "mask": "A000'1010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B UpValue[B] := R[A]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "gettabup",
+      "format": "",
+      "mask": "A000'1011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := UpValue[B][K[C]:shortstring]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "gettable",
+      "format": "",
+      "mask": "A000'1100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B][R[C]]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "geti",
+      "format": "",
+      "mask": "A000'1101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B][C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "getfield",
+      "format": "",
+      "mask": "A000'1110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B][K[C]:shortstring]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "settabup",
+      "format": "",
+      "mask": "A000'1111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C UpValue[A][K[B]:shortstring] := RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "settable",
+      "format": "",
+      "mask": "A001'0000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A][R[B]] := RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "seti",
+      "format": "",
+      "mask": "A001'0001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A][B] := RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "setfield",
+      "format": "",
+      "mask": "A001'0010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A][K[B]:shortstring] := RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "newtable",
+      "format": "",
+      "mask": "A001'0011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C k R[A] := {}",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "self",
+      "format": "",
+      "mask": "A001'0100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A+1] := R[B]; R[A] := R[B][RK(C):string]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "addi",
+      "format": "",
+      "mask": "A001'0101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B sC R[A] := R[B] + sC",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "addk",
+      "format": "",
+      "mask": "A001'0110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] + K[C]:number",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "subk",
+      "format": "",
+      "mask": "A001'0111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] - K[C]:number",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mulk",
+      "format": "",
+      "mask": "A001'1000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] * K[C]:number",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "modk",
+      "format": "",
+      "mask": "A001'1001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] % K[C]:number",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "powk",
+      "format": "",
+      "mask": "A001'1010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] ^ K[C]:number",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "divk",
+      "format": "",
+      "mask": "A001'1011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] / K[C]:number",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "idivk",
+      "format": "",
+      "mask": "A001'1100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] // K[C]:number",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bandk",
+      "format": "",
+      "mask": "A001'1101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] & K[C]:integer",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bork",
+      "format": "",
+      "mask": "A001'1110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] | K[C]:integer",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bxork",
+      "format": "",
+      "mask": "A001'1111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] ~ K[C]:integer",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "shri",
+      "format": "",
+      "mask": "A010'0000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B sC R[A] := R[B] >> sC",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "shli",
+      "format": "",
+      "mask": "A010'0001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B sC R[A] := sC << R[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "add",
+      "format": "",
+      "mask": "A010'0010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] + R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "sub",
+      "format": "",
+      "mask": "A010'0011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] - R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mul",
+      "format": "",
+      "mask": "A010'0100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] * R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mod",
+      "format": "",
+      "mask": "A010'0101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] % R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "pow",
+      "format": "",
+      "mask": "A010'0110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] ^ R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "div",
+      "format": "",
+      "mask": "A010'0111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] / R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "idiv",
+      "format": "",
+      "mask": "A010'1000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] // R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "band",
+      "format": "",
+      "mask": "A010'1001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] & R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bor",
+      "format": "",
+      "mask": "A010'1010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] | R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bxor",
+      "format": "",
+      "mask": "A010'1011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] ~ R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "shl",
+      "format": "",
+      "mask": "A010'1100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] << R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "shr",
+      "format": "",
+      "mask": "A010'1101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] >> R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mmbin",
+      "format": "",
+      "mask": "A010'1110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C call C metamethod over R[A] and R[B] (*)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mmbini",
+      "format": "",
+      "mask": "A010'1111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A sB C k call C metamethod over R[A] and sB",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mmbink",
+      "format": "",
+      "mask": "A011'0000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C k call C metamethod over R[A] and K[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "unm",
+      "format": "",
+      "mask": "A011'0001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A] := -R[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bnot",
+      "format": "",
+      "mask": "A011'0010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A] := ~R[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "not",
+      "format": "",
+      "mask": "A011'0011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A] := not R[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "len",
+      "format": "",
+      "mask": "A011'0100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A] := #R[B] (length operator)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "concat",
+      "format": "",
+      "mask": "A011'0101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A] := R[A].. ... ..R[A + B - 1]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "close",
+      "format": "",
+      "mask": "A011'0110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A close all upvalues >= R[A]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "tbc",
+      "format": "",
+      "mask": "A011'0111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A mark variable A \"to be closed\"",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "jmp",
+      "format": "",
+      "mask": "A011'1000 AAAA'AAAA AAAA'AAAA AAAA'AAAA",
+      "metadata": {
+        "comment": "sJ pc += sJ",
+        "opmode": "isJ"
+      }
+    },
+    {
+      "mnemonic": "eq",
+      "format": "",
+      "mask": "A011'1001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B k if ((R[A] == R[B]) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "lt",
+      "format": "",
+      "mask": "A011'1010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B k if ((R[A] < R[B]) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "le",
+      "format": "",
+      "mask": "A011'1011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B k if ((R[A] <= R[B]) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "eqk",
+      "format": "",
+      "mask": "A011'1100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B k if ((R[A] == K[B]) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "eqi",
+      "format": "",
+      "mask": "A011'1101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A sB k if ((R[A] == sB) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "lti",
+      "format": "",
+      "mask": "A011'1110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A sB k if ((R[A] < sB) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "lei",
+      "format": "",
+      "mask": "A011'1111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A sB k if ((R[A] <= sB) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "gti",
+      "format": "",
+      "mask": "A100'0000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A sB k if ((R[A] > sB) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "gei",
+      "format": "",
+      "mask": "A100'0001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A sB k if ((R[A] >= sB) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "test",
+      "format": "",
+      "mask": "A100'0010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A k if (not R[A] == k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "testset",
+      "format": "",
+      "mask": "A100'0011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B k if (not R[B] == k) then pc++ else R[A] := R[B] (*)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "call",
+      "format": "",
+      "mask": "A100'0100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A], ... ,R[A+C-2] := R[A](R[A+1], ... ,R[A+B-1])",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "tailcall",
+      "format": "",
+      "mask": "A100'0101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C k return R[A](R[A+1], ... ,R[A+B-1])",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "return",
+      "format": "",
+      "mask": "A100'0110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C k return R[A], ... ,R[A+B-2] (see note)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "return0",
+      "format": "",
+      "mask": "A100'0111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "return",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "return1",
+      "format": "",
+      "mask": "A100'1000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A return R[A]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "forloop",
+      "format": "",
+      "mask": "A100'1001 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx update counters; if loop continues then pc-=Bx;",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "forprep",
+      "format": "",
+      "mask": "A100'1010 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx <check values and prepare counters>; if not to run then pc+=Bx+1;",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "tforprep",
+      "format": "",
+      "mask": "A100'1011 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx create upvalue for R[A + 3]; pc+=Bx",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "tforcall",
+      "format": "",
+      "mask": "A100'1100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A C R[A+4], ... ,R[A+3+C] := R[A](R[A+1], R[A+2]);",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "tforloop",
+      "format": "",
+      "mask": "A100'1101 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx if R[A+2] ~= nil then { R[A]=R[A+2]; pc -= Bx }",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "setlist",
+      "format": "",
+      "mask": "A100'1110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C k R[A][C+i] := R[A+i], 1 <= i <= B",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "closure",
+      "format": "",
+      "mask": "A100'1111 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R[A] := closure(KPROTO[Bx])",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "vararg",
+      "format": "",
+      "mask": "A101'0000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A C R[A], R[A+1], ..., R[A+C-2] = vararg",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "varargprep",
+      "format": "",
+      "mask": "A101'0001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A (adjust vararg parameters)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "extraarg",
+      "format": "",
+      "mask": "A101'0010 AAAA'AAAA AAAA'AAAA AAAA'AAAA",
+      "metadata": {
+        "comment": "Ax extra (larger) argument for previous opcode",
+        "opmode": "iAx"
+      }
+    }
+  ]
+}

--- a/disassemblers/lua55.json
+++ b/disassemblers/lua55.json
@@ -1,0 +1,772 @@
+{
+  "name": "Lua5.5",
+  "includes": [],
+  "prefixes": [],
+  "opcodes": [
+    {
+      "mnemonic": "move",
+      "format": "",
+      "mask": "A000'0000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A] := R[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "loadi",
+      "format": "",
+      "mask": "A000'0001 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx R[A] := sBx",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "loadf",
+      "format": "",
+      "mask": "A000'0010 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A sBx R[A] := (lua_Number)sBx",
+        "opmode": "iAsBx"
+      }
+    },
+    {
+      "mnemonic": "loadk",
+      "format": "",
+      "mask": "A000'0011 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R[A] := K[Bx]",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "loadkx",
+      "format": "",
+      "mask": "A000'0100 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A R[A] := K[extra arg]",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "loadfalse",
+      "format": "",
+      "mask": "A000'0101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A R[A] := false",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "lfalseskip",
+      "format": "",
+      "mask": "A000'0110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A R[A] := false; pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "loadtrue",
+      "format": "",
+      "mask": "A000'0111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A R[A] := true",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "loadnil",
+      "format": "",
+      "mask": "A000'1000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A], R[A+1], ..., R[A+B] := nil",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "getupval",
+      "format": "",
+      "mask": "A000'1001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A] := UpValue[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "setupval",
+      "format": "",
+      "mask": "A000'1010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B UpValue[B] := R[A]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "gettabup",
+      "format": "",
+      "mask": "A000'1011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := UpValue[B][K[C]:shortstring]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "gettable",
+      "format": "",
+      "mask": "A000'1100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B][R[C]]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "geti",
+      "format": "",
+      "mask": "A000'1101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B][C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "getfield",
+      "format": "",
+      "mask": "A000'1110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B][K[C]:shortstring]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "settabup",
+      "format": "",
+      "mask": "A000'1111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C UpValue[A][K[B]:shortstring] := RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "settable",
+      "format": "",
+      "mask": "A001'0000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A][R[B]] := RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "seti",
+      "format": "",
+      "mask": "A001'0001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A][B] := RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "setfield",
+      "format": "",
+      "mask": "A001'0010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A][K[B]:shortstring] := RK(C)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "newtable",
+      "format": "",
+      "mask": "A001'0011 AAAA'AAAA CCBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A vB vC k R[A] := {}",
+        "opmode": "ivABC"
+      }
+    },
+    {
+      "mnemonic": "self",
+      "format": "",
+      "mask": "A001'0100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A+1] := R[B]; R[A] := R[B][K[C]:shortstring]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "addi",
+      "format": "",
+      "mask": "A001'0101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B sC R[A] := R[B] + sC",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "addk",
+      "format": "",
+      "mask": "A001'0110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] + K[C]:number",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "subk",
+      "format": "",
+      "mask": "A001'0111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] - K[C]:number",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mulk",
+      "format": "",
+      "mask": "A001'1000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] * K[C]:number",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "modk",
+      "format": "",
+      "mask": "A001'1001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] % K[C]:number",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "powk",
+      "format": "",
+      "mask": "A001'1010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] ^ K[C]:number",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "divk",
+      "format": "",
+      "mask": "A001'1011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] / K[C]:number",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "idivk",
+      "format": "",
+      "mask": "A001'1100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] // K[C]:number",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bandk",
+      "format": "",
+      "mask": "A001'1101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] & K[C]:integer",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bork",
+      "format": "",
+      "mask": "A001'1110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] | K[C]:integer",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bxork",
+      "format": "",
+      "mask": "A001'1111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] ~ K[C]:integer",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "shli",
+      "format": "",
+      "mask": "A010'0000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B sC R[A] := sC << R[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "shri",
+      "format": "",
+      "mask": "A010'0001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B sC R[A] := R[B] >> sC",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "add",
+      "format": "",
+      "mask": "A010'0010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] + R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "sub",
+      "format": "",
+      "mask": "A010'0011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] - R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mul",
+      "format": "",
+      "mask": "A010'0100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] * R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mod",
+      "format": "",
+      "mask": "A010'0101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] % R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "pow",
+      "format": "",
+      "mask": "A010'0110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] ^ R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "div",
+      "format": "",
+      "mask": "A010'0111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] / R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "idiv",
+      "format": "",
+      "mask": "A010'1000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] // R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "band",
+      "format": "",
+      "mask": "A010'1001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] & R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bor",
+      "format": "",
+      "mask": "A010'1010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] | R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bxor",
+      "format": "",
+      "mask": "A010'1011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] ~ R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "shl",
+      "format": "",
+      "mask": "A010'1100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] << R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "shr",
+      "format": "",
+      "mask": "A010'1101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B] >> R[C]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mmbin",
+      "format": "",
+      "mask": "A010'1110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C call C metamethod over R[A] and R[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mmbini",
+      "format": "",
+      "mask": "A010'1111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A sB C k call C metamethod over R[A] and sB",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "mmbink",
+      "format": "",
+      "mask": "A011'0000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C k call C metamethod over R[A] and K[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "unm",
+      "format": "",
+      "mask": "A011'0001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A] := -R[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "bnot",
+      "format": "",
+      "mask": "A011'0010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A] := ~R[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "not",
+      "format": "",
+      "mask": "A011'0011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A] := not R[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "len",
+      "format": "",
+      "mask": "A011'0100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A] := #R[B] (length operator)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "concat",
+      "format": "",
+      "mask": "A011'0101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B R[A] := R[A].. ... ..R[A + B - 1]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "close",
+      "format": "",
+      "mask": "A011'0110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A close all upvalues >= R[A]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "tbc",
+      "format": "",
+      "mask": "A011'0111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A mark variable A \"to be closed\"",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "jmp",
+      "format": "",
+      "mask": "A011'1000 AAAA'AAAA AAAA'AAAA AAAA'AAAA",
+      "metadata": {
+        "comment": "sJ pc += sJ",
+        "opmode": "isJ"
+      }
+    },
+    {
+      "mnemonic": "eq",
+      "format": "",
+      "mask": "A011'1001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B k if ((R[A] == R[B]) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "lt",
+      "format": "",
+      "mask": "A011'1010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B k if ((R[A] < R[B]) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "le",
+      "format": "",
+      "mask": "A011'1011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B k if ((R[A] <= R[B]) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "eqk",
+      "format": "",
+      "mask": "A011'1100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B k if ((R[A] == K[B]) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "eqi",
+      "format": "",
+      "mask": "A011'1101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A sB k if ((R[A] == sB) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "lti",
+      "format": "",
+      "mask": "A011'1110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A sB k if ((R[A] < sB) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "lei",
+      "format": "",
+      "mask": "A011'1111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A sB k if ((R[A] <= sB) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "gti",
+      "format": "",
+      "mask": "A100'0000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A sB k if ((R[A] > sB) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "gei",
+      "format": "",
+      "mask": "A100'0001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A sB k if ((R[A] >= sB) ~= k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "test",
+      "format": "",
+      "mask": "A100'0010 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A k if (not R[A] == k) then pc++",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "testset",
+      "format": "",
+      "mask": "A100'0011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B k if (not R[B] == k) then pc++ else R[A] := R[B]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "call",
+      "format": "",
+      "mask": "A100'0100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A], ... ,R[A+C-2] := R[A](R[A+1], ... ,R[A+B-1])",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "tailcall",
+      "format": "",
+      "mask": "A100'0101 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C k return R[A](R[A+1], ... ,R[A+B-1])",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "return",
+      "format": "",
+      "mask": "A100'0110 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C k return R[A], ... ,R[A+B-2]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "return0",
+      "format": "",
+      "mask": "A100'0111 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "return",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "return1",
+      "format": "",
+      "mask": "A100'1000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A return R[A]",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "forloop",
+      "format": "",
+      "mask": "A100'1001 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx update counters; if loop continues then pc-=Bx;",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "forprep",
+      "format": "",
+      "mask": "A100'1010 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx <check values and prepare counters>; if not to run then pc+=Bx+1;",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "tforprep",
+      "format": "",
+      "mask": "A100'1011 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx create upvalue for R[A + 3]; pc+=Bx",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "tforcall",
+      "format": "",
+      "mask": "A100'1100 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A C R[A+4], ... ,R[A+3+C] := R[A](R[A+1], R[A+2]);",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "tforloop",
+      "format": "",
+      "mask": "A100'1101 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx if R[A+2] ~= nil then { R[A]=R[A+2]; pc -= Bx }",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "setlist",
+      "format": "",
+      "mask": "A100'1110 AAAA'AAAA CCBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A vB vC k R[A][vC+i] := R[A+i], 1 <= i <= vB",
+        "opmode": "ivABC"
+      }
+    },
+    {
+      "mnemonic": "closure",
+      "format": "",
+      "mask": "A100'1111 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx R[A] := closure(KPROTO[Bx])",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "vararg",
+      "format": "",
+      "mask": "A101'0000 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C k R[A], ..., R[A+C-2] = varargs",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "getvarg",
+      "format": "",
+      "mask": "A101'0001 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "A B C R[A] := R[B][R[C]], R[B] is vararg parameter",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "errnnil",
+      "format": "",
+      "mask": "A101'0010 AAAA'AAAA BBBB'BBBB BBBB'BBBB",
+      "metadata": {
+        "comment": "A Bx raise error if R[A] ~= nil (K[Bx - 1] is global name)",
+        "opmode": "iABx"
+      }
+    },
+    {
+      "mnemonic": "varargprep",
+      "format": "",
+      "mask": "A101'0011 AAAA'AAAA BBBB'BBBB CCCC'CCCC",
+      "metadata": {
+        "comment": "(adjust varargs)",
+        "opmode": "iABC"
+      }
+    },
+    {
+      "mnemonic": "extraarg",
+      "format": "",
+      "mask": "A101'0100 AAAA'AAAA AAAA'AAAA AAAA'AAAA",
+      "metadata": {
+        "comment": "Ax extra (larger) argument for previous opcode",
+        "opmode": "iAx"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Generated from opcodes listed in lopcodes.h and lopcodes.c using [this script](https://codeberg.org/neptuwunium/scripts/src/branch/develop/GenerateLuaOpcodes.py).

There is still some improvements possible with formatting, I couldn't get it to properly display values (`0b0100'0001` would display as `loadk 0x40` when it's `loadk 0x01`)

Left in the opcode comments from lua as metadata for if anyone wants to go through and make formatters.

<img width="794" height="935" alt="image" src="https://github.com/user-attachments/assets/4d80dc5b-5da7-4575-9b08-efabf1fd3b63" />
