### PR TITLE
Fix: change gb.hexpat ramSize type from u16 to u32

### DIFF
--- a/patterns/gb.hexpat
+++ b/patterns/gb.hexpat
@@ -41,7 +41,7 @@ namespace format {
 	};
 
 	fn ram_type(u8 ramType) {
-		u16 ramSize;
+		u32 ramSize;
 		u16 ramBanks;
 		if(ramType == 2) {
 			ramSize = 8192;


### PR DESCRIPTION
Changed the type for `ramSize` from `u16` to `u32` to fix overflow for larger RAM sizes in gb.hexpat.