### PR TITLE
patterns: BroEngine resource formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Everything will immediately show up in ImHex's Content Store and gets bundled wi
 | BIN  | | [`patterns/selinux.hexpat`](patterns/selinux.pat) | SE Linux modules |
 | BINK Container | `video/vnd.radgamettools.bink` | [`patterns/bink_container.hexpat`](patterns/bink_container.hexpat) | [RAD Game Tools Bink Video Container files](https://en.wikipedia.org/wiki/Bink_Video) |
 | BINKA  | | [`patterns/binka.hexpat`](patterns/binka.pat) | RAD Game Tools Bink Audio (BINKA) files |
+| BroEngine .anim | | [`patterns/BroEngine/anim.hexpat`](patterns/BroEngine/anim.hexpat) | Bro Engine (World of Tanks: HEAT) Animation |
+| BroEngine .dds | | [`patterns/BroEngine/dds.hexpat`](patterns/BroEngine/dds.hexpat) | Bro Engine (World of Tanks: HEAT) Texture |
+| BroEngine .mesh | | [`patterns/BroEngine/mesh.hexpat`](patterns/BroEngine/mesh.hexpat) | Bro Engine (World of Tanks: HEAT) Mesh |
+| BroEngine .morph | | [`patterns/BroEngine/morph.hexpat`](patterns/BroEngine/morph.hexpat) | Bro Engine (World of Tanks: HEAT) Morph |
+| BroEngine .skel | | [`patterns/BroEngine/skel.hexpat`](patterns/BroEngine/skel.hexpat) | Bro Engine (World of Tanks: HEAT) Skeleton |
 | BSON | `application/bson` | [`patterns/bson.hexpat`](patterns/bson.hexpat) | BSON (Binary JSON) format |
 | BTRFS Send Stream | | [`patterns/btrfs_send_stream.hexpat`](patterns/btrfs_send_stream.hexpat) | BTRFS Send Stream format |
 | bplist | `application/x-bplist` | [`patterns/bplist.hexpat`](patterns/bplist.hexpat) | Apple's binary property list format (bplist) |

--- a/patterns/BroEngine/anim.hexpat
+++ b/patterns/BroEngine/anim.hexpat
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Neptuwunium
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+#pragma once
+#pragma author Neptuwunium
+#pragma description BroEngine Animation
+#pragma filename *.anim
+#pragma array_limit 0x1fffffff
+#pragma pattern_limit 0x1fffffff
+
+#include "BroEngine/bro.hexinc"
+#define __BROENGINE_SKELETON_IMPORTED__
+#include "BroEngine/skel.hexpat"
+
+struct Track {
+	u32 frame_count = parent.frame_count;
+
+	bool rot_is_const;
+	Vector4F rotation[rot_is_const ? 1 : frame_count];
+
+	bool pos_is_const;
+	Vector3F position[pos_is_const ? 1 : frame_count];
+
+	bool scale_is_const;
+	float scale[scale_is_const ? 1 : frame_count];
+};
+
+struct SkeletalAnimation {
+	u16 bone_count;
+	u32 frame_count;
+	float duration;
+
+	Track prefab;
+	Track bones[bone_count];
+	Skeleton skeleton;
+};
+
+SkeletalAnimation anim @ 0;

--- a/patterns/BroEngine/bro.hexinc
+++ b/patterns/BroEngine/bro.hexinc
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Neptuwunium
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+#pragma once
+#pragma author Neptuwunium
+#pragma description BroEngine Common
+
+import type.float16;
+
+struct Vector4<Type> {
+	Type x, y, z, w;
+} [[format("format_vector4")]];
+
+
+struct Vector3<Type> {
+	Type x, y, z;
+} [[format("format_vector3")]];
+
+struct Matrix4x4<Type> {
+	Vector4<Type> m1, m2, m3, m4;
+};
+
+struct Ptr<T, auto baseOffset> {
+	u32 offset;
+
+	if (offset > 0) {
+		T value @ offset + baseOffset [[inline]];
+	}
+};
+
+struct RelPtr<T> {
+	Ptr<T, $ + 4> [[inline]];
+};
+
+struct PString<TLen, TChar> {
+	TLen length;
+	TChar data[length];
+} [[format("format_string"), sealed]];
+
+using half = type::float16;
+using Vector4H = Vector4<half>;
+using Vector4F = Vector4<float>;
+using Vector3F = Vector3<float>;
+using Matrix4x4F = Matrix4x4<float>;
+using PString32 = PString<u32, char>;
+
+fn format_vector3(ref auto vec) {
+	return std::format("{{ {}, {}, {} }}", vec.x, vec.y, vec.z);
+};
+
+fn format_vector4(ref auto vec) {
+	return std::format("{{ {}, {}, {}, {} }}", vec.x, vec.y, vec.z, vec.w);
+};
+
+fn format_string(ref auto pstr) {
+	return std::format("{}", pstr.data);
+};

--- a/patterns/BroEngine/dds.hexpat
+++ b/patterns/BroEngine/dds.hexpat
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Neptuwunium
+//
+// SPDX-License-Identifier: GPL-2
+
+#pragma once
+#pragma author Neptuwunium
+#pragma description BroEngine DDS Texture
+#pragma array_limit 0x1fffffff
+#pragma pattern_limit 0x1fffffff
+
+#include "dds.hexpat"
+
+if (header.reserved0[0] == 0x4477) {
+	u32 compressedMipSizes[dds.mipMapCount];
+}

--- a/patterns/BroEngine/mesh.hexpat
+++ b/patterns/BroEngine/mesh.hexpat
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2026 Neptuwunium
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+#pragma once
+#pragma author Neptuwunium
+#pragma description BroEngine Mesh
+#pragma filename *.mesh
+#pragma array_limit 0x1fffffff
+#pragma pattern_limit 0x1fffffff
+
+import std.sys;
+
+#include "BroEngine/bro.hexinc"
+#define __BROENGINE_SKELETON_IMPORTED__
+#include "BroEngine/skel.hexpat"
+
+struct Submesh {
+	PString32 name;
+
+	u32 flags;
+	u32 first_index;
+	u32 vertex_count;
+	u32 face_count;
+};
+
+struct UVBuffer {
+	u8 uv_type;
+
+	if(uv_type == 1) {
+		half vertex_uv_buffer[parent.vertex_count * 2];
+	} else if(uv_type == 0) {
+		float vertex_uv_buffer[parent.vertex_count * 2];
+	} else {
+		std::assert(false, "uv_type is not 0 or 1");
+	}
+};
+
+bitfield BoneIndirection {
+	index: 24;
+	count: 8;
+};
+
+struct BoneWeight {
+	half weight;
+	u16 index;
+};
+
+// note(neptuwunium): the lack of alignment in this file is making me very upset
+// bro engine would be perfect otherwise lol
+struct Mesh {
+	u32 version;
+	std::assert(version <= 0x19, "version is too new");
+	Vector3F min;
+	Vector3F max;
+	Vector3F scale;
+	float bias;
+	u32 flags;
+
+	u32 submesh_count;
+	std::assert(submesh_count <= 0xff, "submesh count is > 255");
+	Submesh submeshes[submesh_count];
+
+	u32 vertex_count;
+
+	u8 vertex_buffer_type;
+	if(vertex_buffer_type == 0) {
+		Vector3F vertex_position_buffer[vertex_count];
+	} else if(vertex_buffer_type == 1) {
+		Vector4H vertex_position_buffer[vertex_count]; // ? x, y, z, zero. scaled to min/max maybe?
+	} else {
+		std::assert(false, "vertex_buffer_type is not 0 or 1");
+	}
+
+	u32 vertex_tangent_buffer[vertex_count]; // R10G10B10A2 with A2 being the sign for binormal
+	u32 vertex_normal_buffer[vertex_count]; // R10G10B10X2
+
+	u32 num_uvs;
+	std::assert(num_uvs <= 3, "uv count is > 3");
+	UVBuffer uvs[num_uvs];
+
+	u8 color_buffer_type;
+	if(color_buffer_type > 0) {
+		if(color_buffer_type == 1) {
+			u32 color_buffer[vertex_count];
+		} else {
+			std::assert(false, "color_buffer_type is not 0 or 1");
+		}
+	}
+
+	u32 index_buffer_size;
+	if (vertex_count > 0xffff) {
+		u32 index_buffer[index_buffer_size];
+	} else {
+		u16 index_buffer[index_buffer_size * 2];
+	}
+
+	u8 skin_type;
+	if (skin_type > 0) {
+		if (skin_type == 1) { // "soft" skinning
+			u32 weight_count;
+			BoneWeight weight_buffer[weight_count];
+			BoneIndirection skin_buffer[vertex_count]; // bones indirection
+		} else if(skin_type == 2) {
+			u16 skin_buffer[vertex_count]; // "hard" skinning
+		} else {
+			std::assert(false, "skin_type is not 0, 1 or 2");
+		}
+
+		Skeleton skeleton;
+	}
+};
+
+Mesh mesh @ 0;

--- a/patterns/BroEngine/morph.hexpat
+++ b/patterns/BroEngine/morph.hexpat
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Neptuwunium
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+#pragma once
+#pragma author Neptuwunium
+#pragma description BroEngine Morph
+#pragma filename *.morph
+#pragma array_limit 0x1fffffff
+#pragma pattern_limit 0x1fffffff
+
+#include "BroEngine/bro.hexinc"
+
+struct MorphTarget {
+	u32 vertex_start;
+	u32 vertex_count;
+	u32 unknown;
+	PString32 name;
+};
+
+struct MorphVertex {
+	u32 target_vertex;
+	Vector3F position;
+	Vector3F tangent;
+	Vector3F normal;
+	Vector3F bitangent;
+};
+
+struct MorpherLimit {
+	float min;
+	float max;
+};
+
+struct MorpherExtent {
+	float extent;
+	float amount;
+	u32 flags;
+};
+
+struct MorpherTarget {
+	PString32 name;
+	u32 flags;
+	u32 limit_count;
+	MorpherLimit limits[limit_count];
+	u32 extent_count;
+	MorpherExtent extents[extent_count];
+};
+
+struct Morpher {
+	PString32 name;
+	u32 target_count;
+	MorpherTarget targets[target_count];
+};
+
+struct MorphAnimation {
+	u32 count;
+	MorphTarget targets[count];
+
+	u32 vertex_count;
+	MorphVertex vertices[vertex_count];
+
+	u32 morpher_count;
+	Morpher morphers[morpher_count];
+};
+
+MorphAnimation morph @ 0;

--- a/patterns/BroEngine/skel.hexpat
+++ b/patterns/BroEngine/skel.hexpat
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Neptuwunium
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+#pragma once
+
+#ifndef __BROENGINE_SKELETON_IMPORTED__
+#pragma author Neptuwunium
+#pragma description BroEngine Skeleton
+#pragma filename *.skel
+#pragma array_limit 0x1fffffff
+#pragma pattern_limit 0x1fffffff
+#endif
+
+import std.sys;
+
+#include "BroEngine/bro.hexinc"
+
+struct BoneData<auto count> {
+	Matrix4x4F matrices[count];
+	PString32 names[count];
+};
+
+struct BoneChild {
+	u32 relPtr;
+	u32 boneId;
+};
+
+struct BoneInfo {
+	u16 parentIndex;
+	u16 unknown;
+	u32 childCount;
+
+	if (childCount > 0) {
+		BoneChild children[childCount];
+	}
+
+	u32 parentOffset; // doesn't exist on the last one.
+} [[inline]];
+
+struct Skeleton {
+	u32 version;
+	std::assert(version <= 4, "version is too new");
+	u16 boneCount;
+	RelPtr<BoneData<boneCount>> boneData;
+	u32 headerEnd = $ + 4;
+	Ptr<BoneInfo, headerEnd> bones[boneCount];
+	Ptr<BoneInfo, headerEnd> rootBone;
+};
+
+#ifndef __BROENGINE_SKELETON_IMPORTED__
+Skeleton skel @ 0;
+#endif


### PR DESCRIPTION
BroEngine is a proprietary game engine from Wargaming for [World of Tanks: HEAT](https://wotheat.com/).

Note: I researched this some time ago and was hosted on [my own pattern repo](https://codeberg.org/neptuwunium/bt) but decided to upstream it. As such the work is EUPL-1.2, but since I am the sole owner of the files I can dual license or relicense it if necessary. Patterns are validated to work as of the release version of the game, I do not know if they updated the formats in the two months since I developed these.

Since the game and the engine are copyrighted and proprietary, I cannot upload test files without manually making them which I am not interested in doing at this juncture.

Anecdotally, the game compresses these resource files via zstandard. Anyone using these patterns for these resources must first decompress them with zstd. (The whole file is compressed as [a single zstandard stream](https://codeberg.org/neptuwunium/wheat/src/commit/678549ecf427ca1b6479903a172ce21f9dad670b/Wheat/PackageFileSystem.cs#L53-L72).) 