### PR TITLE
Add FLP file pattern to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Everything will immediately show up in ImHex's Content Store and gets bundled wi
 | File System | `application/x-ima` | [`patterns/fs/pattern.hexpat`](patterns/fs/pattern.hexpat) | Drive File System |
 | FLAC | `audio/flac` | [`patterns/flac.hexpat`](patterns/flac.hexpat) | Free Lossless Audio Codec, FLAC Audio Format |
 | FLC/FLIC | | [`patterns/flc.hexpat`](patterns/flc.hexpat) | FLC/FLIC animation file |
+| FLP | `application/x-fruityloops` | [`patterns/flp.hexpat`](patterns/fl.hexpat) | FL Studio project file |
 | FLV | | [`patterns/flv.hexpat`](patterns/flv.hexpat) | FLv animation file |
 | Flipper Zero Settings | | [`patterns/flipper_settings.hexpat`](patterns/flipper_settings.hexpat) | Flipper Zero Settings Files |
 | GB | `application/x-gameboy-rom` | [`patterns/gb.hexpat`](patterns/gb.hexpat) | Game Boy ROM |


### PR DESCRIPTION
Allows my FLP pattern to be downloaded from the Content Store.